### PR TITLE
feat(mac): add read-only UIKit view tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Free Apple Developer signing expires after about 7 days. `ios-use status` and `i
 | `start` / `status` / `stop` | Select, inspect, or release the current target. These are the only Mac-backend lifecycle commands; restart Mac with `stop`, then `start --mac --reuse`. |
 | `activateApp` / `terminateApp` | Open or close an app by bundle ID on a real device or Simulator; activation is UI-ready by default. |
 | `dom` | Print the current semantic UI tree. |
+| `ui-tree` | Inspect UIKit view classes and layout details for the active Mac App; use `dom` for interaction. |
 | `tap` / `longpress` | Act on a label or coordinate. |
 | `swipe` | Scroll by direction/distance or toward a target label. |
 | `input` | Type into the current keyboard focus, optionally tapping a target first. |
@@ -252,6 +253,9 @@ Runtime's owner-only Unix socket. `driver.lock` keeps the Mac backend selected u
 `ios-use stop`, so session commands cannot fall back to XCTest. `status`,
 screenshots, DOM/wait, touch/input, capture, URL delivery, logs, and evidence
 all use that exact PID, executable, session, and prepared generation.
+`ui-tree` is a read-only Mac-only diagnostic that relates a fresh semantic DOM
+target to its current UIKit view subtree. It does not replace `dom`, does not
+act on views, and is unavailable for device and Simulator sessions.
 Lifecycle remains host-owned: `activateApp`, `terminateApp`, `home`, and DDI
 operations are explicitly unsupported while a Mac session is active.
 

--- a/ThirdParty/PlayCover/PlayCover/Headless/PlayCoverPrepareDifferential.swift
+++ b/ThirdParty/PlayCover/PlayCover/Headless/PlayCoverPrepareDifferential.swift
@@ -12,7 +12,7 @@ import MachO
 import injection
 
 private let playCoverPrepareDifferentialEmbeddedSourceClosureSHA256 =
-    "f1efe481ee6d9b4efad35760921d9656df45354450b7454210267d145a2c5f9a"
+    "c38919abab44e4722f29f1917b21e9feae26065d29f9faca556bbd926a715402"
 
 private func playCoverCanonicalExistingURL(_ url: URL) -> URL? {
     guard let resolved = realpath(url.standardizedFileURL.path, nil) else {

--- a/docs/playcover-backend.md
+++ b/docs/playcover-backend.md
@@ -454,9 +454,8 @@ geometry, layout flags, and a small allowlist of public properties for common
 UIKit controls. An optional semantic target is first resolved through one
 fresh Runtime DOM snapshot, then inspected through its current backing view.
 The response is bounded by caller depth (0...20), a fixed 1,000-node limit,
-and bounded strings. Node IDs are snapshot-local paths; object addresses and
-live object registries are never serialized or retained. UI actions continue
-to use DOM rather than `ui-tree`.
+and bounded strings. The nested response exposes no object identity, address,
+or live object registry. UI actions continue to use DOM rather than `ui-tree`.
 
 Tap, long press, and direct swipe use the directly ported PlayTools fake-touch
 backend with begin/move/end/cancel phases and monotonic timing. The Runtime

--- a/docs/playcover-backend.md
+++ b/docs/playcover-backend.md
@@ -448,6 +448,16 @@ match, ambiguity, traits, and `cindex` rules. SwiftUI and WKWebView use their
 accessibility bridges; custom Metal/Unity content is reported as opaque when
 it has no semantic nodes.
 
+`ui-tree` is a separate, read-only Mac Runtime diagnostic. It serializes the
+actual foreground UIKit `UIView` subtree, including concrete class names,
+geometry, layout flags, and a small allowlist of public properties for common
+UIKit controls. An optional semantic target is first resolved through one
+fresh Runtime DOM snapshot, then inspected through its current backing view.
+The response is bounded by caller depth (0...20), a fixed 1,000-node limit,
+and bounded strings. Node IDs are snapshot-local paths; object addresses and
+live object registries are never serialized or retained. UI actions continue
+to use DOM rather than `ui-tree`.
+
 Tap, long press, and direct swipe use the directly ported PlayTools fake-touch
 backend with begin/move/end/cancel phases and monotonic timing. The Runtime
 resolves selectors against a fresh snapshot, performs a UIKit hit test in

--- a/ios-use-skill/SKILL.md
+++ b/ios-use-skill/SKILL.md
@@ -43,7 +43,7 @@ current `IOS_USE_HOME`. Run `ios-use stop` before switching backends.
 - Run `config` on first use, after upgrading ios-use, when `status` reports
   `driver update required`, when signing expires soon, or when signing has
   expired. Refresh before expiry instead of deferring renewal across sessions.
-- Run `start` before `dom`, `tap`, `longpress`, `swipe`, `input`, `waitFor`,
+- Run `start` before `dom`, `ui-tree`, `tap`, `longpress`, `swipe`, `input`, `waitFor`,
   `screenshot`, `capture`, `home`, `dismissAlert`, default `activateApp`,
   `open --dom`, or device-backed proxy commands.
 - Treat the device selected by `start` as the target for all UI commands. To switch
@@ -206,6 +206,19 @@ tail -f <log-file>
 Do not echo signed URLs, tokens, credentials, or unrelated private log content.
 
 ### Debug a Frida-enabled Mac App
+
+When runtime implementation details matter, use semantic DOM to name the
+current UI and `ui-tree` to relate one label to its UIKit subtree:
+
+```bash
+ios-use dom
+ios-use ui-tree --target "导入照片" --depth 6
+```
+
+`ui-tree` is read-only and Mac-only. It shows current view classes, hierarchy,
+geometry, and common public properties; continue to use `dom` labels for UI
+actions. View frames use their parent's coordinates; use DOM geometry for the
+screen position. Do not treat snapshot node IDs as stable across commands.
 
 Read `references/frida-debug.md` first. Prefer stdin for multi-line GumJS and
 use an explicit reset when a failed script may have installed hooks:

--- a/ios-use-skill/SKILL.md
+++ b/ios-use-skill/SKILL.md
@@ -218,7 +218,7 @@ ios-use ui-tree --target "导入照片" --depth 6
 `ui-tree` is read-only and Mac-only. It shows current view classes, hierarchy,
 geometry, and common public properties; continue to use `dom` labels for UI
 actions. View frames use their parent's coordinates; use DOM geometry for the
-screen position. Do not treat snapshot node IDs as stable across commands.
+screen position. Request a fresh tree after the UI changes.
 
 Read `references/frida-debug.md` first. Prefer stdin for multi-line GumJS and
 use an explicit reset when a failed script may have installed hooks:

--- a/playcover-runtime/IOSUsePlayRuntimeDOM.h
+++ b/playcover-runtime/IOSUsePlayRuntimeDOM.h
@@ -61,6 +61,16 @@ IOSUsePlayRuntimeDOMResolveLiveIdentity(
     NSString * _Nullable * _Nullable nativeAlertActionLabel
 );
 
+/// Builds one fresh semantic snapshot, resolves `target` with the standard
+/// visible-label selector, and returns its current backing UIView. This is a
+/// main-thread-only bridge for read-only Runtime diagnostics; no object
+/// identity is serialized or retained beyond the fresh DOM generation.
+FOUNDATION_EXPORT UIView * _Nullable
+IOSUsePlayRuntimeDOMResolveTargetView(
+    NSString *target,
+    NSDictionary<NSString *, id> * _Nullable * _Nullable commandError
+);
+
 /// Revalidates and performs one bounded accessibility action against the
 /// exact bridged element from a fresh Runtime DOM snapshot. The bridge owns
 /// its JavaScript and accepts neither caller scripts nor CSS/XPath selectors.

--- a/playcover-runtime/IOSUsePlayRuntimeDOM.m
+++ b/playcover-runtime/IOSUsePlayRuntimeDOM.m
@@ -223,6 +223,28 @@ typedef NS_ENUM(NSInteger, IOSUseDOMSelectorState) {
 @implementation IOSUseDOMSelectorResult
 @end
 
+static IOSUseDOMSnapshot * _Nullable IOSUseDOMFreshSnapshot(
+    NSTimeInterval queueBudget,
+    IOSUsePlayRuntimeCancellationCheck _Nullable cancellationCheck,
+    NSDictionary<NSString *, id> * _Nullable *commandError
+);
+static IOSUseDOMSelectorResult *IOSUseDOMSelect(
+    IOSUseDOMSnapshot *snapshot,
+    NSString *query,
+    NSString *traits,
+    NSNumber * _Nullable childIndex,
+    NSInteger matchMode,
+    NSRegularExpression * _Nullable expression
+);
+static NSDictionary<NSString *, id> *IOSUseDOMElementJSON(
+    IOSUseCleanNode *node
+);
+static NSArray<NSDictionary<NSString *, id> *> *
+IOSUseDOMCandidatesJSON(
+    NSArray<IOSUseCleanNode *> *matches,
+    NSString * _Nullable rejection
+);
+
 static BOOL IOSUseDOMIsBoolean(id value) {
     return [value isKindOfClass:NSNumber.class] &&
         CFGetTypeID((__bridge CFTypeRef)value) == CFBooleanGetTypeID();
@@ -1879,6 +1901,124 @@ BOOL IOSUsePlayRuntimeDOMResolveLiveIdentity(
         *nativeAlertActionLabel = currentNativeActionLabel;
     }
     return YES;
+}
+
+UIView * _Nullable IOSUsePlayRuntimeDOMResolveTargetView(
+    NSString *target,
+    NSDictionary<NSString *, id> **commandError
+) {
+    NSCAssert(
+        NSThread.isMainThread,
+        @"DOM target view resolution is main-only"
+    );
+    NSString *query = [target stringByTrimmingCharactersInSet:
+        NSCharacterSet.whitespaceAndNewlineCharacterSet];
+    NSDictionary<NSString *, id> *serializedTarget =
+        IOSUseDOMTargetJSON(query ?: @"", @"", nil);
+    if (query.length == 0) {
+        if (commandError != NULL) {
+            *commandError = IOSUseDOMValidationError(
+                @"ui-tree target cannot be empty",
+                serializedTarget
+            );
+        }
+        return nil;
+    }
+
+    NSDictionary<NSString *, id> *snapshotError = nil;
+    IOSUseDOMSnapshot *snapshot = IOSUseDOMFreshSnapshot(
+        IOSUseDOMMainThreadTimeoutSeconds,
+        nil,
+        &snapshotError
+    );
+    if (snapshot == nil) {
+        if (commandError != NULL) {
+            *commandError = snapshotError;
+        }
+        return nil;
+    }
+    IOSUseDOMSelectorResult *result = IOSUseDOMSelect(
+        snapshot,
+        query,
+        @"",
+        nil,
+        0,
+        nil
+    );
+    if (result.state != IOSUseDOMSelectorStateFound) {
+        if (commandError != NULL) {
+            BOOL ambiguous =
+                result.state == IOSUseDOMSelectorStateAmbiguous;
+            *commandError = IOSUseDOMError(
+                ambiguous ? @"element_ambiguous" : @"element_not_found",
+                ambiguous
+                    ? [NSString stringWithFormat:
+                        @"ui-tree target '%@' is ambiguous (%lu matches); "
+                         "use `ios-use dom` to choose a unique label or "
+                         "identifier, or omit --target to inspect the "
+                         "bounded full tree",
+                        query,
+                        (unsigned long)result.matches.count]
+                    : [NSString stringWithFormat:
+                        @"ui-tree target '%@' was not found in a fresh DOM; "
+                         "run `ios-use dom` and retry with a current label "
+                         "or identifier, or omit --target to inspect the "
+                         "bounded full tree",
+                        query],
+                @"lookup",
+                @"lookup",
+                YES,
+                serializedTarget,
+                result.matches.count,
+                IOSUseDOMCandidatesJSON(result.matches, nil)
+            );
+        }
+        return nil;
+    }
+
+    NSDictionary<NSString *, id> *serialized =
+        IOSUseDOMElementJSON(result.matches.firstObject);
+    id liveObject = nil;
+    UIView *interactionView = nil;
+    if (!IOSUsePlayRuntimeDOMResolveLiveIdentity(
+            serialized,
+            &liveObject,
+            &interactionView,
+            nil
+        )) {
+        if (commandError != NULL) {
+            *commandError = IOSUseDOMError(
+                @"element_stale",
+                @"ui-tree target changed after the fresh DOM snapshot",
+                @"lookup",
+                @"lookup",
+                YES,
+                serializedTarget,
+                1,
+                IOSUseDOMCandidatesJSON(result.matches, nil)
+            );
+        }
+        return nil;
+    }
+    UIView *view = [liveObject isKindOfClass:UIView.class]
+        ? (UIView *)liveObject
+        : interactionView;
+    if (view == nil) {
+        if (commandError != NULL) {
+            *commandError = IOSUseDOMError(
+                @"element_not_hittable",
+                @"ui-tree target has no current backing UIView",
+                @"lookup",
+                @"lookup",
+                YES,
+                serializedTarget,
+                1,
+                IOSUseDOMCandidatesJSON(result.matches, nil)
+            );
+        }
+        return nil;
+    }
+    return view;
 }
 
 static void IOSUseDOMRegisterWebBridgeElement(

--- a/playcover-runtime/IOSUsePlayRuntimeSocket.m
+++ b/playcover-runtime/IOSUsePlayRuntimeSocket.m
@@ -2,6 +2,7 @@
 #import "IOSUsePlayRuntime.h"
 #import "IOSUsePlayRuntimeAutomation.h"
 #import "IOSUsePlayRuntimeDOM.h"
+#import "IOSUsePlayRuntimeViewTree.h"
 #import "IOSUsePlayAppKitBridge.h"
 #import "IOSUsePlayHookRegistry.h"
 #import "IOSUsePlayRuntimeScreenshot.h"
@@ -363,6 +364,7 @@ static NSArray<NSString *> *IOSUseCapabilities(
         @"diagnostics",
         @"screenshot",
         @"dom",
+        @"uiTree",
         @"waitFor",
         @"tap",
         @"longPress",
@@ -1804,6 +1806,7 @@ static BOOL IOSUseRuntimeIsUICommand(NSString *command) {
         commands = [NSSet setWithArray:@[
             @"screenshot",
             @"dom",
+            @"uiTree",
             @"waitFor",
             @"tap",
             @"longPress",
@@ -2345,6 +2348,23 @@ static NSDictionary<NSString *, id> *IOSUseHandleRequestBody(
             );
         }
         payload[@"dom"] = dom;
+    } else if ([command isEqualToString:@"uiTree"]) {
+        NSDictionary<NSString *, id> *commandError = nil;
+        NSDictionary<NSString *, id> *uiTree =
+            IOSUsePlayRuntimeViewTreeCommand(arguments, &commandError);
+        if (uiTree == nil) {
+            return IOSUseErrorEnvelope(
+                requestID,
+                commandError ?: IOSUseErrorObject(
+                    @"ui_tree_snapshot_failed",
+                    @"Runtime UIKit view hierarchy snapshot failed",
+                    @"lookup",
+                    @"snapshot",
+                    YES
+                )
+            );
+        }
+        payload[@"uiTree"] = uiTree;
     } else if ([command isEqualToString:@"waitFor"]) {
         NSDictionary<NSString *, id> *commandError = nil;
         NSDictionary<NSString *, id> *waitFor =

--- a/playcover-runtime/IOSUsePlayRuntimeViewTree.h
+++ b/playcover-runtime/IOSUsePlayRuntimeViewTree.h
@@ -1,0 +1,23 @@
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Returns a bounded, read-only snapshot of the active UIKit UIView hierarchy.
+/// UIKit work is marshalled to the main queue. On failure, `commandError`
+/// contains the complete Runtime JSON error object.
+FOUNDATION_EXPORT NSDictionary<NSString *, id> * _Nullable
+IOSUsePlayRuntimeViewTreeCommand(
+    NSDictionary<NSString *, id> *arguments,
+    NSDictionary<NSString *, id> * _Nullable * _Nullable commandError
+);
+
+#if defined(IOS_USE_PLAY_RUNTIME_VIEW_TREE_TESTING)
+FOUNDATION_EXPORT NSDictionary<NSString *, id> *
+IOSUsePlayRuntimeViewTreeSnapshotForTesting(
+    NSArray<UIView *> *roots,
+    NSInteger maximumDepth
+);
+#endif
+
+NS_ASSUME_NONNULL_END

--- a/playcover-runtime/IOSUsePlayRuntimeViewTree.m
+++ b/playcover-runtime/IOSUsePlayRuntimeViewTree.m
@@ -291,22 +291,10 @@ static NSDictionary<NSString *, id> *IOSUseViewTreeProperties(
     return properties;
 }
 
-static NSString *IOSUseViewTreeNodeID(NSArray<NSNumber *> *path) {
-    NSMutableArray<NSString *> *parts =
-        [NSMutableArray arrayWithCapacity:path.count];
-    for (NSNumber *component in path) {
-        [parts addObject:component.stringValue];
-    }
-    return [@"v" stringByAppendingString:
-        [parts componentsJoinedByString:@"."]];
-}
-
 static NSDictionary<NSString *, id> * _Nullable
 IOSUseViewTreeSerializeView(
     UIView *view,
-    NSArray<NSNumber *> *path,
     NSInteger depth,
-    NSInteger index,
     IOSUseViewTreeContext *context
 ) {
     if (context.nodeCount >= IOSUseViewTreeMaximumNodes) {
@@ -322,15 +310,10 @@ IOSUseViewTreeSerializeView(
             for (NSUInteger childIndex = 0;
                  childIndex < subviews.count;
                  childIndex += 1) {
-                NSMutableArray<NSNumber *> *childPath =
-                    [path mutableCopy];
-                [childPath addObject:@(childIndex)];
                 NSDictionary<NSString *, id> *child =
                     IOSUseViewTreeSerializeView(
                         subviews[childIndex],
-                        childPath,
                         depth + 1,
-                        (NSInteger)childIndex,
                         context
                     );
                 if (child != nil) {
@@ -346,10 +329,6 @@ IOSUseViewTreeSerializeView(
         }
         NSString *controllerClass = IOSUseViewTreeControllerClass(view);
         return @{
-            @"nodeID": IOSUseViewTreeNodeID(path),
-            @"path": path,
-            @"depth": @(depth),
-            @"index": @(index),
             @"childCount": @(subviews.count),
             @"class": NSStringFromClass(view.class) ?: @"UIView",
             @"viewControllerClass": controllerClass ?: NSNull.null,
@@ -398,9 +377,7 @@ static NSDictionary<NSString *, id> *IOSUseViewTreeSnapshot(
         NSDictionary<NSString *, id> *root =
             IOSUseViewTreeSerializeView(
                 roots[index],
-                @[@(index)],
                 0,
-                (NSInteger)index,
                 context
             );
         if (context.failureMessage != nil) {
@@ -420,7 +397,6 @@ static NSDictionary<NSString *, id> *IOSUseViewTreeSnapshot(
         }
     }
     return @{
-        @"source": @"uikit-view-hierarchy",
         @"target": target ?: NSNull.null,
         @"maxDepth": @(maximumDepth),
         @"nodeCount": @(context.nodeCount),

--- a/playcover-runtime/IOSUsePlayRuntimeViewTree.m
+++ b/playcover-runtime/IOSUsePlayRuntimeViewTree.m
@@ -1,0 +1,562 @@
+#import "IOSUsePlayRuntimeViewTree.h"
+
+#import "IOSUsePlayRuntimeDOM.h"
+
+#import <CoreFoundation/CoreFoundation.h>
+#import <math.h>
+
+static const NSInteger IOSUseViewTreeMaximumDepth = 20;
+static const NSUInteger IOSUseViewTreeMaximumNodes = 1000;
+static const NSUInteger IOSUseViewTreeMaximumStringLength = 512;
+
+@interface IOSUseViewTreeContext : NSObject
+@property(nonatomic) NSInteger maximumDepth;
+@property(nonatomic) NSUInteger nodeCount;
+@property(nonatomic) BOOL truncated;
+@property(nonatomic, copy, nullable) NSString *failureMessage;
+@end
+
+@implementation IOSUseViewTreeContext
+@end
+
+static NSDictionary<NSString *, id> *IOSUseViewTreeError(
+    NSString *code,
+    NSString *message,
+    NSString *category,
+    NSString *phase,
+    BOOL retryable
+) {
+    return @{
+        @"code": code,
+        @"message": message,
+        @"details": @{
+            @"category": category,
+            @"phase": phase,
+            @"retryable": @(retryable),
+            @"fatal": @NO,
+            @"candidateCount": @0,
+            @"candidates": @[],
+            @"suggestions": @[],
+        },
+    };
+}
+
+static BOOL IOSUseViewTreeIsInteger(id value) {
+    if (![value isKindOfClass:NSNumber.class] ||
+        CFGetTypeID((__bridge CFTypeRef)value) ==
+            CFBooleanGetTypeID()) {
+        return NO;
+    }
+    double number = [value doubleValue];
+    return isfinite(number) && floor(number) == number;
+}
+
+static NSString * _Nullable IOSUseViewTreeString(
+    id _Nullable value
+) {
+    if (![value isKindOfClass:NSString.class]) {
+        return nil;
+    }
+    NSString *string = value;
+    if (string.length <= IOSUseViewTreeMaximumStringLength) {
+        return string;
+    }
+    NSRange range = [string rangeOfComposedCharacterSequencesForRange:
+        NSMakeRange(0, IOSUseViewTreeMaximumStringLength)];
+    return [[string substringWithRange:range]
+        stringByAppendingString:@"…"];
+}
+
+static NSDictionary<NSString *, NSNumber *> *IOSUseViewTreeRect(
+    CGRect rect
+) {
+    return @{
+        @"x": @(rect.origin.x),
+        @"y": @(rect.origin.y),
+        @"width": @(rect.size.width),
+        @"height": @(rect.size.height),
+    };
+}
+
+static NSDictionary<NSString *, NSNumber *> *IOSUseViewTreeSize(
+    CGSize size
+) {
+    return @{
+        @"width": @(size.width),
+        @"height": @(size.height),
+    };
+}
+
+static NSDictionary<NSString *, NSNumber *> *IOSUseViewTreePoint(
+    CGPoint point
+) {
+    return @{
+        @"x": @(point.x),
+        @"y": @(point.y),
+    };
+}
+
+static NSDictionary<NSString *, NSNumber *> *IOSUseViewTreeInsets(
+    UIEdgeInsets insets
+) {
+    return @{
+        @"top": @(insets.top),
+        @"left": @(insets.left),
+        @"bottom": @(insets.bottom),
+        @"right": @(insets.right),
+    };
+}
+
+static NSString *IOSUseViewTreeContentMode(
+    UIViewContentMode mode
+) {
+    switch (mode) {
+        case UIViewContentModeScaleToFill: return @"scaleToFill";
+        case UIViewContentModeScaleAspectFit: return @"scaleAspectFit";
+        case UIViewContentModeScaleAspectFill: return @"scaleAspectFill";
+        case UIViewContentModeRedraw: return @"redraw";
+        case UIViewContentModeCenter: return @"center";
+        case UIViewContentModeTop: return @"top";
+        case UIViewContentModeBottom: return @"bottom";
+        case UIViewContentModeLeft: return @"left";
+        case UIViewContentModeRight: return @"right";
+        case UIViewContentModeTopLeft: return @"topLeft";
+        case UIViewContentModeTopRight: return @"topRight";
+        case UIViewContentModeBottomLeft: return @"bottomLeft";
+        case UIViewContentModeBottomRight: return @"bottomRight";
+    }
+    return [NSString stringWithFormat:@"unknown(%ld)", (long)mode];
+}
+
+static NSString *IOSUseViewTreeTextAlignment(
+    NSTextAlignment alignment
+) {
+    switch (alignment) {
+        case NSTextAlignmentLeft: return @"left";
+        case NSTextAlignmentCenter: return @"center";
+        case NSTextAlignmentRight: return @"right";
+        case NSTextAlignmentJustified: return @"justified";
+        case NSTextAlignmentNatural: return @"natural";
+    }
+    return [NSString stringWithFormat:
+        @"unknown(%ld)",
+        (long)alignment];
+}
+
+static NSString *IOSUseViewTreeImageRenderingMode(
+    UIImageRenderingMode mode
+) {
+    switch (mode) {
+        case UIImageRenderingModeAutomatic: return @"automatic";
+        case UIImageRenderingModeAlwaysOriginal: return @"alwaysOriginal";
+        case UIImageRenderingModeAlwaysTemplate: return @"alwaysTemplate";
+    }
+    return [NSString stringWithFormat:@"unknown(%ld)", (long)mode];
+}
+
+static NSString *IOSUseViewTreeStackAxis(
+    UILayoutConstraintAxis axis
+) {
+    switch (axis) {
+        case UILayoutConstraintAxisHorizontal: return @"horizontal";
+        case UILayoutConstraintAxisVertical: return @"vertical";
+    }
+    return [NSString stringWithFormat:@"unknown(%ld)", (long)axis];
+}
+
+static NSString *IOSUseViewTreeStackAlignment(
+    UIStackViewAlignment alignment,
+    UILayoutConstraintAxis axis
+) {
+    switch ((NSInteger)alignment) {
+        case 0: return @"fill";
+        case 1:
+            return axis == UILayoutConstraintAxisHorizontal
+                ? @"top"
+                : @"leading";
+        case 2: return @"firstBaseline";
+        case 3: return @"center";
+        case 4:
+            return axis == UILayoutConstraintAxisHorizontal
+                ? @"bottom"
+                : @"trailing";
+        case 5: return @"lastBaseline";
+        default:
+            return [NSString stringWithFormat:
+                @"unknown(%ld)",
+                (long)alignment];
+    }
+}
+
+static NSString *IOSUseViewTreeStackDistribution(
+    UIStackViewDistribution distribution
+) {
+    switch (distribution) {
+        case UIStackViewDistributionFill: return @"fill";
+        case UIStackViewDistributionFillEqually: return @"fillEqually";
+        case UIStackViewDistributionFillProportionally:
+            return @"fillProportionally";
+        case UIStackViewDistributionEqualSpacing: return @"equalSpacing";
+        case UIStackViewDistributionEqualCentering: return @"equalCentering";
+    }
+    return [NSString stringWithFormat:
+        @"unknown(%ld)",
+        (long)distribution];
+}
+
+static NSString *IOSUseViewTreeControllerClass(UIView *view) {
+    UIResponder *responder = view.nextResponder;
+    NSUInteger traversed = 0;
+    while (responder != nil && traversed < 64) {
+        if ([responder isKindOfClass:UIViewController.class]) {
+            return NSStringFromClass(responder.class);
+        }
+        responder = responder.nextResponder;
+        traversed += 1;
+    }
+    return nil;
+}
+
+static NSDictionary<NSString *, id> *IOSUseViewTreeProperties(
+    UIView *view
+) {
+    NSMutableDictionary<NSString *, id> *properties =
+        [NSMutableDictionary dictionary];
+    if ([view isKindOfClass:UILabel.class]) {
+        UILabel *label = (UILabel *)view;
+        properties[@"text"] =
+            IOSUseViewTreeString(label.text) ?: NSNull.null;
+        properties[@"fontName"] =
+            IOSUseViewTreeString(label.font.fontName) ?: NSNull.null;
+        properties[@"fontSize"] = @(label.font.pointSize);
+        properties[@"numberOfLines"] = @(label.numberOfLines);
+        properties[@"textAlignment"] =
+            IOSUseViewTreeTextAlignment(label.textAlignment);
+    }
+    if ([view isKindOfClass:UIImageView.class]) {
+        UIImageView *imageView = (UIImageView *)view;
+        UIImage *image = imageView.image;
+        properties[@"image"] = image == nil
+            ? (id)NSNull.null
+            : @{
+                @"size": IOSUseViewTreeSize(image.size),
+                @"scale": @(image.scale),
+                @"renderingMode":
+                    IOSUseViewTreeImageRenderingMode(image.renderingMode),
+            };
+        properties[@"highlighted"] = @(imageView.highlighted);
+    }
+    if ([view isKindOfClass:UIButton.class]) {
+        UIButton *button = (UIButton *)view;
+        properties[@"title"] =
+            IOSUseViewTreeString(button.currentTitle) ?: NSNull.null;
+        properties[@"enabled"] = @(button.enabled);
+        properties[@"selected"] = @(button.selected);
+        if (button.titleLabel.font != nil) {
+            properties[@"titleFontName"] =
+                IOSUseViewTreeString(button.titleLabel.font.fontName)
+                ?: NSNull.null;
+            properties[@"titleFontSize"] =
+                @(button.titleLabel.font.pointSize);
+        }
+    }
+    if ([view isKindOfClass:UIScrollView.class]) {
+        UIScrollView *scrollView = (UIScrollView *)view;
+        properties[@"contentSize"] =
+            IOSUseViewTreeSize(scrollView.contentSize);
+        properties[@"contentOffset"] =
+            IOSUseViewTreePoint(scrollView.contentOffset);
+        properties[@"contentInset"] =
+            IOSUseViewTreeInsets(scrollView.contentInset);
+        properties[@"adjustedContentInset"] =
+            IOSUseViewTreeInsets(scrollView.adjustedContentInset);
+        properties[@"scrollEnabled"] = @(scrollView.scrollEnabled);
+        properties[@"bounces"] = @(scrollView.bounces);
+        properties[@"pagingEnabled"] = @(scrollView.pagingEnabled);
+    }
+    if ([view isKindOfClass:UIStackView.class]) {
+        UIStackView *stackView = (UIStackView *)view;
+        properties[@"axis"] = IOSUseViewTreeStackAxis(stackView.axis);
+        properties[@"spacing"] = @(stackView.spacing);
+        properties[@"alignment"] = IOSUseViewTreeStackAlignment(
+            stackView.alignment,
+            stackView.axis
+        );
+        properties[@"distribution"] = IOSUseViewTreeStackDistribution(
+            stackView.distribution
+        );
+        properties[@"arrangedSubviewCount"] =
+            @(stackView.arrangedSubviews.count);
+    }
+    return properties;
+}
+
+static NSString *IOSUseViewTreeNodeID(NSArray<NSNumber *> *path) {
+    NSMutableArray<NSString *> *parts =
+        [NSMutableArray arrayWithCapacity:path.count];
+    for (NSNumber *component in path) {
+        [parts addObject:component.stringValue];
+    }
+    return [@"v" stringByAppendingString:
+        [parts componentsJoinedByString:@"."]];
+}
+
+static NSDictionary<NSString *, id> * _Nullable
+IOSUseViewTreeSerializeView(
+    UIView *view,
+    NSArray<NSNumber *> *path,
+    NSInteger depth,
+    NSInteger index,
+    IOSUseViewTreeContext *context
+) {
+    if (context.nodeCount >= IOSUseViewTreeMaximumNodes) {
+        context.truncated = YES;
+        return nil;
+    }
+    @try {
+        context.nodeCount += 1;
+        NSArray<UIView *> *subviews = [view.subviews copy] ?: @[];
+        NSMutableArray<NSDictionary<NSString *, id> *> *children =
+            [NSMutableArray array];
+        if (depth < context.maximumDepth) {
+            for (NSUInteger childIndex = 0;
+                 childIndex < subviews.count;
+                 childIndex += 1) {
+                NSMutableArray<NSNumber *> *childPath =
+                    [path mutableCopy];
+                [childPath addObject:@(childIndex)];
+                NSDictionary<NSString *, id> *child =
+                    IOSUseViewTreeSerializeView(
+                        subviews[childIndex],
+                        childPath,
+                        depth + 1,
+                        (NSInteger)childIndex,
+                        context
+                    );
+                if (child != nil) {
+                    [children addObject:child];
+                }
+                if (context.nodeCount >= IOSUseViewTreeMaximumNodes) {
+                    context.truncated = YES;
+                    break;
+                }
+            }
+        } else if (subviews.count > 0) {
+            context.truncated = YES;
+        }
+        NSString *controllerClass = IOSUseViewTreeControllerClass(view);
+        return @{
+            @"nodeID": IOSUseViewTreeNodeID(path),
+            @"path": path,
+            @"depth": @(depth),
+            @"index": @(index),
+            @"childCount": @(subviews.count),
+            @"class": NSStringFromClass(view.class) ?: @"UIView",
+            @"viewControllerClass": controllerClass ?: NSNull.null,
+            @"frame": IOSUseViewTreeRect(view.frame),
+            @"bounds": IOSUseViewTreeRect(view.bounds),
+            @"hidden": @(view.hidden),
+            @"alpha": @(view.alpha),
+            @"userInteractionEnabled": @(view.userInteractionEnabled),
+            @"clipsToBounds": @(view.clipsToBounds),
+            @"contentMode": IOSUseViewTreeContentMode(view.contentMode),
+            @"accessibilityIdentifier":
+                IOSUseViewTreeString(view.accessibilityIdentifier)
+                    ?: NSNull.null,
+            @"accessibilityLabel":
+                IOSUseViewTreeString(view.accessibilityLabel)
+                    ?: NSNull.null,
+            @"layout": @{
+                @"ambiguous": @(view.hasAmbiguousLayout),
+                @"translatesAutoresizingMaskIntoConstraints":
+                    @(view.translatesAutoresizingMaskIntoConstraints),
+                @"constraintCount": @(view.constraints.count),
+            },
+            @"properties": IOSUseViewTreeProperties(view),
+            @"subviews": children,
+        };
+    } @catch (NSException *exception) {
+        context.failureMessage = [NSString stringWithFormat:
+            @"%@ while reading %@",
+            exception.name ?: @"Objective-C exception",
+            NSStringFromClass(view.class) ?: @"UIView"];
+        return nil;
+    }
+}
+
+static NSDictionary<NSString *, id> *IOSUseViewTreeSnapshot(
+    NSArray<UIView *> *roots,
+    NSString * _Nullable target,
+    NSInteger maximumDepth,
+    NSDictionary<NSString *, id> **commandError
+) {
+    IOSUseViewTreeContext *context = [IOSUseViewTreeContext new];
+    context.maximumDepth = maximumDepth;
+    NSMutableArray<NSDictionary<NSString *, id> *> *serialized =
+        [NSMutableArray array];
+    for (NSUInteger index = 0; index < roots.count; index += 1) {
+        NSDictionary<NSString *, id> *root =
+            IOSUseViewTreeSerializeView(
+                roots[index],
+                @[@(index)],
+                0,
+                (NSInteger)index,
+                context
+            );
+        if (context.failureMessage != nil) {
+            if (commandError != NULL) {
+                *commandError = IOSUseViewTreeError(
+                    @"ui_tree_snapshot_failed",
+                    context.failureMessage,
+                    @"internal",
+                    @"snapshot",
+                    YES
+                );
+            }
+            return nil;
+        }
+        if (root != nil) {
+            [serialized addObject:root];
+        }
+    }
+    return @{
+        @"source": @"uikit-view-hierarchy",
+        @"target": target ?: NSNull.null,
+        @"maxDepth": @(maximumDepth),
+        @"nodeCount": @(context.nodeCount),
+        @"truncated": @(context.truncated),
+        @"roots": serialized,
+    };
+}
+
+static NSArray<UIView *> *IOSUseViewTreeWindowRoots(void) {
+    NSMutableArray<UIWindow *> *windows = [NSMutableArray array];
+    for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
+        if (![scene isKindOfClass:UIWindowScene.class] ||
+            (scene.activationState != UISceneActivationStateForegroundActive &&
+             scene.activationState != UISceneActivationStateForegroundInactive)) {
+            continue;
+        }
+        for (UIWindow *window in ((UIWindowScene *)scene).windows) {
+            if (!window.hidden && window.alpha > 0 &&
+                !CGRectIsEmpty(window.bounds)) {
+                [windows addObject:window];
+            }
+        }
+    }
+    return [windows sortedArrayUsingComparator:
+        ^NSComparisonResult(UIWindow *left, UIWindow *right) {
+            if (left.windowLevel < right.windowLevel) {
+                return NSOrderedAscending;
+            }
+            if (left.windowLevel > right.windowLevel) {
+                return NSOrderedDescending;
+            }
+            return NSOrderedSame;
+        }];
+}
+
+NSDictionary<NSString *, id> * _Nullable
+IOSUsePlayRuntimeViewTreeCommand(
+    NSDictionary<NSString *, id> *arguments,
+    NSDictionary<NSString *, id> **commandError
+) {
+    NSSet<NSString *> *keys = [NSSet setWithArray:@[
+        @"target",
+        @"depth",
+    ]];
+    if (![arguments isKindOfClass:NSDictionary.class] ||
+        ![[NSSet setWithArray:arguments.allKeys] isEqualToSet:keys] ||
+        !(arguments[@"target"] == NSNull.null ||
+          [arguments[@"target"] isKindOfClass:NSString.class]) ||
+        !IOSUseViewTreeIsInteger(arguments[@"depth"])) {
+        if (commandError != NULL) {
+            *commandError = IOSUseViewTreeError(
+                @"invalid_arguments",
+                @"ui-tree arguments must contain target (string or null) and integer depth",
+                @"validation",
+                @"validation",
+                NO
+            );
+        }
+        return nil;
+    }
+    NSInteger maximumDepth = [arguments[@"depth"] integerValue];
+    if (maximumDepth < 0 || maximumDepth > IOSUseViewTreeMaximumDepth) {
+        if (commandError != NULL) {
+            *commandError = IOSUseViewTreeError(
+                @"invalid_arguments",
+                @"ui-tree depth must be between 0 and 20",
+                @"validation",
+                @"validation",
+                NO
+            );
+        }
+        return nil;
+    }
+    NSString *target = arguments[@"target"] == NSNull.null
+        ? nil
+        : arguments[@"target"];
+    __block NSDictionary<NSString *, id> *result = nil;
+    __block NSDictionary<NSString *, id> *failure = nil;
+    void (^snapshot)(void) = ^{
+        NSArray<UIView *> *roots;
+        if (target != nil) {
+            UIView *view = IOSUsePlayRuntimeDOMResolveTargetView(
+                target,
+                &failure
+            );
+            roots = view == nil ? nil : @[view];
+        } else {
+            roots = IOSUseViewTreeWindowRoots();
+            if (roots.count == 0) {
+                failure = IOSUseViewTreeError(
+                    @"ui_tree_unavailable",
+                    @"no visible foreground UIKit windows are available",
+                    @"precondition",
+                    @"snapshot",
+                    YES
+                );
+            }
+        }
+        if (roots != nil && failure == nil) {
+            result = IOSUseViewTreeSnapshot(
+                roots,
+                target,
+                maximumDepth,
+                &failure
+            );
+        }
+    };
+    if (NSThread.isMainThread) {
+        snapshot();
+    } else {
+        dispatch_sync(dispatch_get_main_queue(), snapshot);
+    }
+    if (result == nil && commandError != NULL) {
+        *commandError = failure ?: IOSUseViewTreeError(
+            @"ui_tree_snapshot_failed",
+            @"UIKit view hierarchy snapshot failed",
+            @"internal",
+            @"snapshot",
+            YES
+        );
+    }
+    return result;
+}
+
+#if defined(IOS_USE_PLAY_RUNTIME_VIEW_TREE_TESTING)
+NSDictionary<NSString *, id> *
+IOSUsePlayRuntimeViewTreeSnapshotForTesting(
+    NSArray<UIView *> *roots,
+    NSInteger maximumDepth
+) {
+    NSCAssert(NSThread.isMainThread, @"view-tree test snapshot is main-only");
+    return IOSUseViewTreeSnapshot(
+        roots,
+        nil,
+        maximumDepth,
+        NULL
+    );
+}
+#endif

--- a/playcover-runtime/tests/ViewTreeContractTests.m
+++ b/playcover-runtime/tests/ViewTreeContractTests.m
@@ -1,0 +1,141 @@
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+#import "IOSUsePlayRuntimeDOM.h"
+#import "IOSUsePlayRuntimeViewTree.h"
+
+UIView * _Nullable IOSUsePlayRuntimeDOMResolveTargetView(
+    NSString *target,
+    NSDictionary<NSString *, id> **commandError
+) {
+    (void)target;
+    (void)commandError;
+    return nil;
+}
+
+static BOOL IOSUseViewTreeRequire(BOOL condition, NSString *message) {
+    if (!condition) {
+        fprintf(stderr, "[view-tree-contract] %s\n", message.UTF8String);
+    }
+    return condition;
+}
+
+static NSDictionary<NSString *, id> *IOSUseViewTreeFirstSubview(
+    NSDictionary<NSString *, id> *node
+) {
+    NSArray<NSDictionary<NSString *, id> *> *subviews = node[@"subviews"];
+    return subviews.firstObject;
+}
+
+int main(void) {
+    @autoreleasepool {
+        BOOL passed = YES;
+
+        UIView *root = [[UIView alloc] initWithFrame:
+            CGRectMake(0, 0, 430, 932)];
+        root.accessibilityIdentifier = @"fixture-root";
+
+        UIStackView *stack = [[UIStackView alloc] initWithFrame:
+            CGRectMake(20, 40, 300, 100)];
+        stack.axis = UILayoutConstraintAxisHorizontal;
+        stack.spacing = 12;
+        [root addSubview:stack];
+
+        UILabel *label = [[UILabel alloc] initWithFrame:
+            CGRectMake(0, 0, 120, 40)];
+        label.text = @"Fixture title";
+        label.font = [UIFont systemFontOfSize:19];
+        label.numberOfLines = 2;
+        [stack addArrangedSubview:label];
+
+        NSDictionary<NSString *, id> *snapshot =
+            IOSUsePlayRuntimeViewTreeSnapshotForTesting(@[root], 3);
+        NSArray<NSDictionary<NSString *, id> *> *roots = snapshot[@"roots"];
+        NSDictionary<NSString *, id> *rootNode = roots.firstObject;
+        NSDictionary<NSString *, id> *stackNode =
+            IOSUseViewTreeFirstSubview(rootNode);
+        NSDictionary<NSString *, id> *labelNode =
+            IOSUseViewTreeFirstSubview(stackNode);
+
+        passed &= IOSUseViewTreeRequire(
+            [snapshot[@"source"] isEqual:@"uikit-view-hierarchy"] &&
+                [snapshot[@"nodeCount"] integerValue] == 3 &&
+                ![snapshot[@"truncated"] boolValue] &&
+                roots.count == 1,
+            @"snapshot summary changed"
+        );
+        passed &= IOSUseViewTreeRequire(
+            [rootNode[@"nodeID"] isEqual:@"v0"] &&
+                [rootNode[@"class"] isEqual:@"UIView"] &&
+                [rootNode[@"accessibilityIdentifier"]
+                    isEqual:@"fixture-root"] &&
+                [rootNode[@"frame"][@"width"] doubleValue] == 430,
+            @"root identity or geometry changed"
+        );
+        passed &= IOSUseViewTreeRequire(
+            [stackNode[@"nodeID"] isEqual:@"v0.0"] &&
+                [stackNode[@"class"] isEqual:@"UIStackView"] &&
+                [stackNode[@"properties"][@"axis"]
+                    isEqual:@"horizontal"] &&
+                [stackNode[@"properties"][@"alignment"]
+                    isEqual:@"fill"] &&
+                [stackNode[@"properties"][@"distribution"]
+                    isEqual:@"fill"] &&
+                [stackNode[@"properties"][@"spacing"] doubleValue] == 12 &&
+                [stackNode[@"properties"][@"arrangedSubviewCount"]
+                    integerValue] == 1,
+            @"stack-view properties changed"
+        );
+        passed &= IOSUseViewTreeRequire(
+            [labelNode[@"nodeID"] isEqual:@"v0.0.0"] &&
+                [labelNode[@"class"] isEqual:@"UILabel"] &&
+                [labelNode[@"properties"][@"text"]
+                    isEqual:@"Fixture title"] &&
+                [labelNode[@"properties"][@"fontSize"] doubleValue] == 19,
+            @"label properties changed"
+        );
+
+        NSError *jsonError = nil;
+        NSData *json = [NSJSONSerialization dataWithJSONObject:snapshot
+                                                       options:0
+                                                         error:&jsonError];
+        NSString *jsonText = json == nil
+            ? nil
+            : [[NSString alloc] initWithData:json
+                                    encoding:NSUTF8StringEncoding];
+        passed &= IOSUseViewTreeRequire(
+            jsonError == nil &&
+                [jsonText rangeOfString:@"address"].location == NSNotFound,
+            @"snapshot serialized a process address"
+        );
+
+        NSDictionary<NSString *, id> *shallow =
+            IOSUsePlayRuntimeViewTreeSnapshotForTesting(@[root], 1);
+        NSDictionary<NSString *, id> *shallowStack =
+            IOSUseViewTreeFirstSubview([shallow[@"roots"] firstObject]);
+        passed &= IOSUseViewTreeRequire(
+            [shallow[@"truncated"] boolValue] &&
+                [shallow[@"nodeCount"] integerValue] == 2 &&
+                [shallowStack[@"subviews"] count] == 0,
+            @"depth bound did not truncate descendants"
+        );
+
+        NSDictionary<NSString *, id> *commandError = nil;
+        NSDictionary<NSString *, id> *invalid =
+            IOSUsePlayRuntimeViewTreeCommand(
+                @{@"target": NSNull.null, @"depth": @21},
+                &commandError
+            );
+        passed &= IOSUseViewTreeRequire(
+            invalid == nil &&
+                [commandError[@"code"] isEqual:@"invalid_arguments"],
+            @"invalid depth did not fail closed"
+        );
+
+        if (!passed) {
+            return 1;
+        }
+        fprintf(stderr, "[view-tree-contract] PASS\n");
+        return 0;
+    }
+}

--- a/playcover-runtime/tests/ViewTreeContractTests.m
+++ b/playcover-runtime/tests/ViewTreeContractTests.m
@@ -58,23 +58,20 @@ int main(void) {
             IOSUseViewTreeFirstSubview(stackNode);
 
         passed &= IOSUseViewTreeRequire(
-            [snapshot[@"source"] isEqual:@"uikit-view-hierarchy"] &&
-                [snapshot[@"nodeCount"] integerValue] == 3 &&
+            [snapshot[@"nodeCount"] integerValue] == 3 &&
                 ![snapshot[@"truncated"] boolValue] &&
                 roots.count == 1,
             @"snapshot summary changed"
         );
         passed &= IOSUseViewTreeRequire(
-            [rootNode[@"nodeID"] isEqual:@"v0"] &&
-                [rootNode[@"class"] isEqual:@"UIView"] &&
+            [rootNode[@"class"] isEqual:@"UIView"] &&
                 [rootNode[@"accessibilityIdentifier"]
                     isEqual:@"fixture-root"] &&
                 [rootNode[@"frame"][@"width"] doubleValue] == 430,
             @"root identity or geometry changed"
         );
         passed &= IOSUseViewTreeRequire(
-            [stackNode[@"nodeID"] isEqual:@"v0.0"] &&
-                [stackNode[@"class"] isEqual:@"UIStackView"] &&
+            [stackNode[@"class"] isEqual:@"UIStackView"] &&
                 [stackNode[@"properties"][@"axis"]
                     isEqual:@"horizontal"] &&
                 [stackNode[@"properties"][@"alignment"]
@@ -87,8 +84,7 @@ int main(void) {
             @"stack-view properties changed"
         );
         passed &= IOSUseViewTreeRequire(
-            [labelNode[@"nodeID"] isEqual:@"v0.0.0"] &&
-                [labelNode[@"class"] isEqual:@"UILabel"] &&
+            [labelNode[@"class"] isEqual:@"UILabel"] &&
                 [labelNode[@"properties"][@"text"]
                     isEqual:@"Fixture title"] &&
                 [labelNode[@"properties"][@"fontSize"] doubleValue] == 19,

--- a/release-notes/CHANGELOG-v2.0.0.md
+++ b/release-notes/CHANGELOG-v2.0.0.md
@@ -12,6 +12,9 @@
   update time without deleting data.
 - `ios-use status` now reports Mac Runtime resources, signing readiness, and
   session state even when no Mac App is running.
+- Added `ios-use ui-tree`, a read-only Mac-only diagnostic that maps an
+  optional fresh semantic target to its current UIKit view subtree, including
+  class, hierarchy, geometry, and common public view properties.
 - Mac semantic swipes can reveal virtualized or initially off-screen targets
   from a visible anchor and now report a classified no-effect/boundary error
   instead of claiming success when content did not move.

--- a/scripts/test_playcover_cgshw_compositor.sh
+++ b/scripts/test_playcover_cgshw_compositor.sh
@@ -161,6 +161,26 @@ xcrun --sdk macosx clang \
 
 "$IOS_USE_SMOKE_TEMP/DeviceIdentityContractTests"
 
+xcrun --sdk macosx clang \
+  -target arm64-apple-ios13.1-macabi \
+  -D IOS_USE_PLAY_RUNTIME_VIEW_TREE_TESTING \
+  -fobjc-arc \
+  -fblocks \
+  -fmodules \
+  -Wall \
+  -Wextra \
+  -Werror \
+  -iframework "$IOS_USE_MACOS_SDK/System/iOSSupport/System/Library/Frameworks" \
+  -F "$IOS_USE_MACOS_SDK/System/iOSSupport/System/Library/Frameworks" \
+  -framework Foundation \
+  -framework UIKit \
+  -I "$IOS_USE_REPO_ROOT/playcover-runtime" \
+  "$IOS_USE_REPO_ROOT/playcover-runtime/IOSUsePlayRuntimeViewTree.m" \
+  "$IOS_USE_REPO_ROOT/playcover-runtime/tests/ViewTreeContractTests.m" \
+  -o "$IOS_USE_SMOKE_TEMP/ViewTreeContractTests"
+
+"$IOS_USE_SMOKE_TEMP/ViewTreeContractTests"
+
 if rg -n \
   '\[\[[^]]*(UIWindow|UIView)[^]]*alloc|DynamicIsland|HomeIndicator|NSTimer|drawRect:|additionalSafeAreaInsets[[:space:]]*=' \
   "$IOS_USE_REPO_ROOT/playcover-runtime/IOSUsePlaySafeAreaCompatibility.m"

--- a/scripts/test_playcover_fixture_live.sh
+++ b/scripts/test_playcover_fixture_live.sh
@@ -2593,7 +2593,6 @@ assert_json dom_initial '
 record_case ui_tree_navigation ui-tree \
   --target 'fixture.uikit.navigation-bar' --depth 5 --json
 assert_json ui_tree_navigation '
-  .data.source == "uikit-view-hierarchy" and
   .data.target == "fixture.uikit.navigation-bar" and
   .data.nodeCount >= 1 and
   (.data.roots | length) == 1 and

--- a/scripts/test_playcover_fixture_live.sh
+++ b/scripts/test_playcover_fixture_live.sh
@@ -2590,6 +2590,21 @@ assert_json dom_initial '
   (($header.frame[3] - 129) | fabs) <= 0.5
 '
 
+record_case ui_tree_navigation ui-tree \
+  --target 'fixture.uikit.navigation-bar' --depth 5 --json
+assert_json ui_tree_navigation '
+  .data.source == "uikit-view-hierarchy" and
+  .data.target == "fixture.uikit.navigation-bar" and
+  .data.nodeCount >= 1 and
+  (.data.roots | length) == 1 and
+  .data.roots[0].class == "UINavigationBar" and
+  .data.roots[0].accessibilityIdentifier ==
+    "fixture.uikit.navigation-bar" and
+  ([.data.roots[0] | .. | objects |
+    select(.class? == "UILabel")] | length) >= 1 and
+  ([.data | .. | objects | select(has("address"))] | length) == 0
+'
+
 absolute_tap_x="$(
   jq -er '
     [.data.elements[] |

--- a/swift-cli/Sources/IOSUseCLI/Backends/PlayCover/PlayCoverRuntimeClient.swift
+++ b/swift-cli/Sources/IOSUseCLI/Backends/PlayCover/PlayCoverRuntimeClient.swift
@@ -406,10 +406,6 @@ struct PlayCoverRuntimeUITreeLayout: Codable, Equatable, Sendable {
 }
 
 struct PlayCoverRuntimeUITreeNode: Codable, Equatable, Sendable {
-    let nodeID: String
-    let path: [Int]
-    let depth: Int
-    let index: Int
     let childCount: Int
     let `class`: String
     let viewControllerClass: String?
@@ -428,7 +424,6 @@ struct PlayCoverRuntimeUITreeNode: Codable, Equatable, Sendable {
 }
 
 struct PlayCoverRuntimeUITreePayload: Codable, Equatable, Sendable {
-    let source: String
     let target: String?
     let maxDepth: Int
     let nodeCount: Int

--- a/swift-cli/Sources/IOSUseCLI/Backends/PlayCover/PlayCoverRuntimeClient.swift
+++ b/swift-cli/Sources/IOSUseCLI/Backends/PlayCover/PlayCoverRuntimeClient.swift
@@ -7,6 +7,7 @@ enum PlayCoverRuntimeCommand: String, Codable, Sendable {
     case diagnostics
     case screenshot
     case dom
+    case uiTree
     case waitFor
     case tap
     case longPress
@@ -184,6 +185,37 @@ struct PlayCoverRuntimeDOMArguments: Codable, Equatable, Sendable {
     let waitQuiescence: Bool
 }
 
+struct PlayCoverRuntimeUITreeArguments: Codable, Equatable, Sendable {
+    let target: String?
+    let depth: Int
+
+    private enum CodingKeys: String, CodingKey {
+        case target
+        case depth
+    }
+
+    init(target: String?, depth: Int) {
+        self.target = target
+        self.depth = depth
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        target = try container.decodeIfPresent(String.self, forKey: .target)
+        depth = try container.decode(Int.self, forKey: .depth)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        if let target {
+            try container.encode(target, forKey: .target)
+        } else {
+            try container.encodeNil(forKey: .target)
+        }
+        try container.encode(depth, forKey: .depth)
+    }
+}
+
 typealias PlayCoverRuntimeWaitTarget = PlayCoverRuntimeTarget
 
 struct PlayCoverRuntimeWaitForArguments: Codable, Equatable, Sendable {
@@ -277,6 +309,7 @@ struct PlayCoverRuntimeDebugArguments: Codable, Equatable, Sendable {
 enum PlayCoverRuntimeRequestArguments: Encodable, Equatable, Sendable {
     case empty(PlayCoverRuntimeEmptyArguments = .init())
     case dom(PlayCoverRuntimeDOMArguments)
+    case uiTree(PlayCoverRuntimeUITreeArguments)
     case waitFor(PlayCoverRuntimeWaitForArguments)
     case tap(PlayCoverRuntimeTapArguments)
     case longPress(PlayCoverRuntimeLongPressArguments)
@@ -294,6 +327,8 @@ enum PlayCoverRuntimeRequestArguments: Encodable, Equatable, Sendable {
         case .empty(let arguments):
             try arguments.encode(to: encoder)
         case .dom(let arguments):
+            try arguments.encode(to: encoder)
+        case .uiTree(let arguments):
             try arguments.encode(to: encoder)
         case .waitFor(let arguments):
             try arguments.encode(to: encoder)
@@ -362,6 +397,43 @@ struct PlayCoverRuntimeDOMPayload: Codable, Equatable, Sendable {
     let raw: String
     let snapshotGeneration: Int64
     let elements: [PlayCoverRuntimeDOMElement]
+}
+
+struct PlayCoverRuntimeUITreeLayout: Codable, Equatable, Sendable {
+    let ambiguous: Bool
+    let translatesAutoresizingMaskIntoConstraints: Bool
+    let constraintCount: Int
+}
+
+struct PlayCoverRuntimeUITreeNode: Codable, Equatable, Sendable {
+    let nodeID: String
+    let path: [Int]
+    let depth: Int
+    let index: Int
+    let childCount: Int
+    let `class`: String
+    let viewControllerClass: String?
+    let frame: PlayCoverRuntimeFrame
+    let bounds: PlayCoverRuntimeFrame
+    let hidden: Bool
+    let alpha: Double
+    let userInteractionEnabled: Bool
+    let clipsToBounds: Bool
+    let contentMode: String
+    let accessibilityIdentifier: String?
+    let accessibilityLabel: String?
+    let layout: PlayCoverRuntimeUITreeLayout
+    let properties: [String: PlayCoverRuntimeJSONValue]
+    let subviews: [PlayCoverRuntimeUITreeNode]
+}
+
+struct PlayCoverRuntimeUITreePayload: Codable, Equatable, Sendable {
+    let source: String
+    let target: String?
+    let maxDepth: Int
+    let nodeCount: Int
+    let truncated: Bool
+    let roots: [PlayCoverRuntimeUITreeNode]
 }
 
 struct PlayCoverRuntimeElementSummary: Codable, Equatable, Sendable {
@@ -597,6 +669,10 @@ private struct PlayCoverRuntimeDOMResult: Codable {
     let dom: PlayCoverRuntimeDOMPayload
 }
 
+private struct PlayCoverRuntimeUITreeResult: Codable {
+    let uiTree: PlayCoverRuntimeUITreePayload
+}
+
 private struct PlayCoverRuntimeWaitForResult: Codable {
     let waitFor: PlayCoverRuntimeWaitForPayload
 }
@@ -639,6 +715,7 @@ enum PlayCoverRuntimeResponsePayload: Equatable, Sendable {
     case diagnostics(PlayCoverRuntimeDiagnosticsPayload)
     case screenshot(PlayCoverRuntimeScreenshotResult)
     case dom(PlayCoverRuntimeDOMPayload)
+    case uiTree(PlayCoverRuntimeUITreePayload)
     case waitFor(PlayCoverRuntimeWaitForPayload)
     case tap(PlayCoverRuntimeActionPayload)
     case longPress(PlayCoverRuntimeActionPayload)
@@ -1005,6 +1082,20 @@ final class PlayCoverRuntimeClient {
         return payload
     }
 
+    func uiTree(
+        _ arguments: PlayCoverRuntimeUITreeArguments
+    ) throws -> PlayCoverRuntimeUITreePayload {
+        guard case .uiTree(let payload) = try request(
+            .uiTree,
+            arguments: .uiTree(arguments)
+        ) else {
+            throw PlayCoverRuntimeClientError.malformedResponse(
+                "ui-tree response type mismatch"
+            )
+        }
+        return payload
+    }
+
     func waitFor(
         _ arguments: PlayCoverRuntimeWaitForArguments
     ) throws -> PlayCoverRuntimeWaitForPayload {
@@ -1283,6 +1374,10 @@ final class PlayCoverRuntimeClient {
             let payload: PlayCoverRuntimeDOMResult =
                 try performRequest(command, arguments: arguments)
             return .dom(payload.dom)
+        case .uiTree:
+            let payload: PlayCoverRuntimeUITreeResult =
+                try performRequest(command, arguments: arguments)
+            return .uiTree(payload.uiTree)
         case .waitFor:
             let payload: PlayCoverRuntimeWaitForResult =
                 try performRequest(command, arguments: arguments)

--- a/swift-cli/Sources/IOSUseCLI/Backends/PlayCover/PlayCoverService.swift
+++ b/swift-cli/Sources/IOSUseCLI/Backends/PlayCover/PlayCoverService.swift
@@ -2077,7 +2077,7 @@ public enum PlayCoverService {
             )
         }
         var expectedCapabilities: Set<String> = [
-            "hello", "ping", "diagnostics", "screenshot", "dom",
+            "hello", "ping", "diagnostics", "screenshot", "dom", "uiTree",
             "waitFor", "tap", "longPress", "swipe", "input",
             "dismissAlert", "dismissAlertByLabel", "open",
         ]

--- a/swift-cli/Sources/IOSUseCLI/Backends/PlayCover/PlayCoverUITreeService.swift
+++ b/swift-cli/Sources/IOSUseCLI/Backends/PlayCover/PlayCoverUITreeService.swift
@@ -78,7 +78,6 @@ enum PlayCoverUITreeService {
         _ payload: PlayCoverRuntimeUITreePayload
     ) -> MachineValue {
         .object([
-            "source": .string(payload.source),
             "target": payload.target.map(MachineValue.string) ?? .null,
             "maxDepth": .integer(payload.maxDepth),
             "nodeCount": .integer(payload.nodeCount),
@@ -96,7 +95,7 @@ enum PlayCoverUITreeService {
     ) {
         let branch = isLast ? "└─ " : "├─ "
         let frame = node.frame
-        var summary = "\(prefix)\(branch)\(node.class) \(node.nodeID)"
+        var summary = "\(prefix)\(branch)\(node.class)"
         summary += String(
             format: " frame=(%.1f,%.1f %.1fx%.1f)",
             frame.x,
@@ -158,10 +157,6 @@ enum PlayCoverUITreeService {
         _ node: PlayCoverRuntimeUITreeNode
     ) -> MachineValue {
         .object([
-            "nodeID": .string(node.nodeID),
-            "path": .array(node.path.map(MachineValue.integer)),
-            "depth": .integer(node.depth),
-            "index": .integer(node.index),
             "childCount": .integer(node.childCount),
             "class": .string(node.class),
             "viewControllerClass": node.viewControllerClass

--- a/swift-cli/Sources/IOSUseCLI/Backends/PlayCover/PlayCoverUITreeService.swift
+++ b/swift-cli/Sources/IOSUseCLI/Backends/PlayCover/PlayCoverUITreeService.swift
@@ -1,0 +1,237 @@
+import Foundation
+import IOSUseProtocol
+
+enum PlayCoverUITreeService {
+    enum Error:
+        Swift.Error,
+        Equatable,
+        CustomStringConvertible,
+        MachineErrorConvertible,
+        Sendable
+    {
+        case requiresMacSession
+
+        var description: String {
+            "`ios-use ui-tree` requires an active Mac session; "
+                + "run `ios-use stop`, then `ios-use start --mac ...`"
+        }
+
+        var machineError: MachineError {
+            MachineError(
+                message: description,
+                category: IOSUseErrorCategory.session,
+                code: "mac_session_required",
+                phase: IOSUseErrorPhase.session,
+                retryable: true,
+                fatal: false,
+                mutationMayHaveApplied: false
+            )
+        }
+    }
+
+    static func run(
+        options: UITreeOptions,
+        paths: IOSUsePaths
+    ) throws -> PlayCoverRuntimeUITreePayload {
+        let session = try SessionService.requireDriverLock(paths: paths)
+        guard session.deviceType == PlayCoverSessionService.deviceType else {
+            throw Error.requiresMacSession
+        }
+        let refreshAlertStatus =
+            CLIInvocationContext.current?.claimAlertRefresh() ?? true
+        let client = try PlayCoverDriverClient.runtimeClient(
+            for: session,
+            timeoutSeconds: PlayCoverRuntimeClient.defaultTimeoutSeconds,
+            refreshAlertStatus: refreshAlertStatus
+        )
+        return try client.uiTree(
+            PlayCoverRuntimeUITreeArguments(
+                target: options.target,
+                depth: options.depth
+            )
+        )
+    }
+
+    static func format(_ payload: PlayCoverRuntimeUITreePayload) -> String {
+        var lines = [
+            "UIKit view tree · \(payload.nodeCount) nodes · depth limit \(payload.maxDepth)",
+        ]
+        if let target = payload.target {
+            lines.append("Target: \(target)")
+        }
+        for (index, root) in payload.roots.enumerated() {
+            append(
+                root,
+                prefix: "",
+                isLast: index == payload.roots.count - 1,
+                parentViewControllerClass: nil,
+                to: &lines
+            )
+        }
+        if payload.truncated {
+            lines.append("… output truncated by the depth or node limit")
+        }
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    static func machineData(
+        _ payload: PlayCoverRuntimeUITreePayload
+    ) -> MachineValue {
+        .object([
+            "source": .string(payload.source),
+            "target": payload.target.map(MachineValue.string) ?? .null,
+            "maxDepth": .integer(payload.maxDepth),
+            "nodeCount": .integer(payload.nodeCount),
+            "truncated": .boolean(payload.truncated),
+            "roots": .array(payload.roots.map(machineNode)),
+        ])
+    }
+
+    private static func append(
+        _ node: PlayCoverRuntimeUITreeNode,
+        prefix: String,
+        isLast: Bool,
+        parentViewControllerClass: String?,
+        to lines: inout [String]
+    ) {
+        let branch = isLast ? "└─ " : "├─ "
+        let frame = node.frame
+        var summary = "\(prefix)\(branch)\(node.class) \(node.nodeID)"
+        summary += String(
+            format: " frame=(%.1f,%.1f %.1fx%.1f)",
+            frame.x,
+            frame.y,
+            frame.width,
+            frame.height
+        )
+        if let viewControllerClass = node.viewControllerClass,
+           viewControllerClass != parentViewControllerClass {
+            summary += " vc=\(viewControllerClass)"
+        }
+        if node.hidden {
+            summary += " hidden"
+        }
+        if node.alpha < 0.999 {
+            summary += String(format: " alpha=%.3f", node.alpha)
+        }
+        if !node.userInteractionEnabled {
+            summary += " interaction=off"
+        }
+        if node.properties["image"] != nil,
+           node.contentMode != "scaleToFill" {
+            summary += " contentMode=\(node.contentMode)"
+        }
+        if node.clipsToBounds {
+            summary += " clips"
+        }
+        if let label = node.accessibilityLabel, !label.isEmpty {
+            summary += " label=\(quoted(label))"
+        }
+        if let identifier = node.accessibilityIdentifier,
+           !identifier.isEmpty {
+            summary += " identifier=\(quoted(identifier))"
+        }
+        let propertyText: [String] = node.properties.keys.sorted().map { key in
+            let value = node.properties[key]!
+            return "\(key)=\(display(value))"
+        }
+        if !propertyText.isEmpty {
+            summary += " {\(propertyText.joined(separator: ", "))}"
+        }
+        lines.append(summary)
+
+        let childPrefix = prefix + (isLast ? "   " : "│  ")
+        let currentViewControllerClass =
+            node.viewControllerClass ?? parentViewControllerClass
+        for (index, child) in node.subviews.enumerated() {
+            append(
+                child,
+                prefix: childPrefix,
+                isLast: index == node.subviews.count - 1,
+                parentViewControllerClass: currentViewControllerClass,
+                to: &lines
+            )
+        }
+    }
+
+    private static func machineNode(
+        _ node: PlayCoverRuntimeUITreeNode
+    ) -> MachineValue {
+        .object([
+            "nodeID": .string(node.nodeID),
+            "path": .array(node.path.map(MachineValue.integer)),
+            "depth": .integer(node.depth),
+            "index": .integer(node.index),
+            "childCount": .integer(node.childCount),
+            "class": .string(node.class),
+            "viewControllerClass": node.viewControllerClass
+                .map(MachineValue.string) ?? .null,
+            "frame": machineFrame(node.frame),
+            "bounds": machineFrame(node.bounds),
+            "hidden": .boolean(node.hidden),
+            "alpha": .double(node.alpha),
+            "userInteractionEnabled": .boolean(
+                node.userInteractionEnabled
+            ),
+            "clipsToBounds": .boolean(node.clipsToBounds),
+            "contentMode": .string(node.contentMode),
+            "accessibilityIdentifier": node.accessibilityIdentifier
+                .map(MachineValue.string) ?? .null,
+            "accessibilityLabel": node.accessibilityLabel
+                .map(MachineValue.string) ?? .null,
+            "layout": .object([
+                "ambiguous": .boolean(node.layout.ambiguous),
+                "translatesAutoresizingMaskIntoConstraints": .boolean(
+                    node.layout.translatesAutoresizingMaskIntoConstraints
+                ),
+                "constraintCount": .integer(node.layout.constraintCount),
+            ]),
+            "properties": .object(
+                node.properties.mapValues(
+                    StatusService.playCoverRuntimeJSONMachineValue
+                )
+            ),
+            "subviews": .array(node.subviews.map(machineNode)),
+        ])
+    }
+
+    private static func machineFrame(
+        _ frame: PlayCoverRuntimeFrame
+    ) -> MachineValue {
+        .object([
+            "x": .double(frame.x),
+            "y": .double(frame.y),
+            "width": .double(frame.width),
+            "height": .double(frame.height),
+        ])
+    }
+
+    private static func display(
+        _ value: PlayCoverRuntimeJSONValue
+    ) -> String {
+        switch value {
+        case .null:
+            return "null"
+        case .bool(let value):
+            return value ? "true" : "false"
+        case .number(let value):
+            return value.rounded() == value
+                ? String(Int(value))
+                : String(format: "%.3f", value)
+        case .string(let value):
+            return quoted(value)
+        case .array(let values):
+            return "[" + values.map(display).joined(separator: ",") + "]"
+        case .object(let values):
+            return "{" + values.keys.sorted().compactMap { key in
+                values[key].map { "\(key):\(display($0))" }
+            }.joined(separator: ",") + "}"
+        }
+    }
+
+    private static func quoted(_ value: String) -> String {
+        let encoded = try? JSONEncoder().encode(value)
+        return encoded.flatMap { String(data: $0, encoding: .utf8) }
+            ?? "\"\(value)\""
+    }
+}

--- a/swift-cli/Sources/IOSUseCLI/CLI/CLIHelp.swift
+++ b/swift-cli/Sources/IOSUseCLI/CLI/CLIHelp.swift
@@ -21,7 +21,7 @@ enum CLIHelp {
           -V, --version    Show version
 
         Commands:
-          du, status, config, start, stop, dom, waitFor, screenshot, capture, tap, longpress, input, swipe
+          du, status, config, start, stop, dom, ui-tree, waitFor, screenshot, capture, tap, longpress, input, swipe
           activateApp, terminateApp, home, open, dismissAlert, debug, media, install, uninstall, apps, ddi-mount, proxy, oslog, nslog
 
         """
@@ -257,6 +257,25 @@ enum CLIHelp {
                     "--wait-quiescence   Wait until the UI is idle before returning a fresh DOM",
                 ]
             )
+        case "ui-tree":
+            return """
+            Usage: ios-use ui-tree [--target <semantic-target>] [--depth <0...20>] [--json]
+
+            Inspect the current UIKit view hierarchy of the active Mac App.
+            This is a read-only Mac-backend diagnostic for relating runtime
+            views to source code. Use `dom` for stable UI interaction.
+            Frames use each view's superview coordinate space; use `dom` for
+            screen-level semantic geometry.
+
+            Options:
+              --target <semantic-target>  Inspect the UIView subtree backing one fresh DOM match
+              --depth <0...20>            Maximum descendant depth; default 8
+              --json                      Print the common machine-readable envelope
+
+            Requires an active Mac session. It is not available for real
+            devices or Simulators and never falls back to XCTest.
+
+            """
         case "waitFor":
             return driverHelp(
                 usage: "ios-use waitFor <target> [--timeout <duration>] [--match <mode>] [--traits <traits>] [--cindex <index>] [--gone]",

--- a/swift-cli/Sources/IOSUseCLI/CLI/CLIParser.swift
+++ b/swift-cli/Sources/IOSUseCLI/CLI/CLIParser.swift
@@ -57,6 +57,8 @@ public enum CLIParser {
             parsed = .driver(try parseSwipe(&parser))
         case "dom":
             parsed = .driver(try parseDom(&parser))
+        case "ui-tree":
+            parsed = .uiTree(try parseUITree(&parser))
         case "screenshot":
             parsed = .driver(try parseScreenshot(&parser))
         case "capture":
@@ -84,7 +86,7 @@ public enum CLIParser {
             switch parsed {
             case .du, .start, .stop, .status, .install, .apps, .open,
                     .config, .appLifecycle, .driver, .mediaImport,
-                    .debug:
+                    .debug, .uiTree:
                 break
             default:
                 throw CLIParseError.unknownOption("--json")
@@ -100,7 +102,7 @@ public enum CLIParser {
             "--offset", "--offset-ratio", "--traits", "--cindex", "--duration", "--tap",
             "--label", "--content", "--delete", "--to", "--from", "--dir", "--distance",
             "--match", "--fps", "--index", "--process", "--pid", "--output", "--runtime",
-            "--app", "-i"
+            "--app", "--target", "--depth", "-i"
         ]
         var normalized: [String] = []
         var json = false
@@ -298,6 +300,51 @@ public enum CLIParser {
             }
         }
         return DebugOptions(script: script, stream: stream, reset: reset)
+    }
+
+    private static func parseUITree(
+        _ parser: inout ArgumentParser
+    ) throws -> UITreeOptions {
+        var target: String?
+        var depth = 8
+        var depthWasProvided = false
+        while let arg = parser.consume() {
+            switch arg {
+            case "--target":
+                guard target == nil else {
+                    throw CLIParseError.invalidValue(
+                        "--target may only be provided once"
+                    )
+                }
+                let value = try parser.value(for: arg)
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !value.isEmpty else {
+                    throw CLIParseError.invalidValue(
+                        "--target cannot be empty"
+                    )
+                }
+                target = value
+            case "--depth":
+                guard !depthWasProvided else {
+                    throw CLIParseError.invalidValue(
+                        "--depth may only be provided once"
+                    )
+                }
+                depthWasProvided = true
+                depth = try parseIntStrict(
+                    parser.valueAllowingLeadingDash(for: arg),
+                    label: arg
+                )
+                guard (0...20).contains(depth) else {
+                    throw CLIParseError.invalidValue(
+                        "--depth must be between 0 and 20"
+                    )
+                }
+            default:
+                throw CLIParseError.unknownOption(arg)
+            }
+        }
+        return UITreeOptions(target: target, depth: depth)
     }
 
     private static func parseInstall(_ parser: inout ArgumentParser) throws -> AppInstallOptions {

--- a/swift-cli/Sources/IOSUseCLI/CLI/CommandModels.swift
+++ b/swift-cli/Sources/IOSUseCLI/CLI/CommandModels.swift
@@ -20,6 +20,7 @@ public enum ParsedCommand: Equatable, Sendable {
     case nslog(NSLogOptions)
     case proxy(ProxyCommand)
     case debug(DebugOptions)
+    case uiTree(UITreeOptions)
 
     public var commandName: String {
         switch self {
@@ -41,6 +42,7 @@ public enum ParsedCommand: Equatable, Sendable {
         case .nslog: return "nslog"
         case .proxy(let command): return "proxy \(command.subcommand)"
         case .debug: return "debug"
+        case .uiTree: return "ui-tree"
         }
     }
 }
@@ -139,6 +141,16 @@ public struct DebugOptions: Equatable, Sendable {
         self.script = script
         self.stream = stream
         self.reset = reset
+    }
+}
+
+public struct UITreeOptions: Equatable, Sendable {
+    public var target: String?
+    public var depth: Int
+
+    public init(target: String? = nil, depth: Int = 8) {
+        self.target = target
+        self.depth = depth
     }
 }
 

--- a/swift-cli/Sources/IOSUseCLI/CLI/IOSUseCLI.swift
+++ b/swift-cli/Sources/IOSUseCLI/CLI/IOSUseCLI.swift
@@ -401,6 +401,8 @@ public struct IOSUseCLI: Sendable {
             }
         case .debug(let options):
             return executeDebug(options, json: json)
+        case .uiTree(let options):
+            return executeUITree(options, json: json)
         case .install(let options):
             do {
                 let result = try AppManagementService.installResult(options: options, paths: paths)
@@ -619,7 +621,7 @@ public struct IOSUseCLI: Sendable {
             return nil
         }
         switch command {
-        case .du, .status, .config, .start, .stop, .capture, .open, .oslog, .debug:
+        case .du, .status, .config, .start, .stop, .capture, .open, .oslog, .debug, .uiTree:
             return nil
         case .mediaImport:
             return nil
@@ -891,6 +893,34 @@ public struct IOSUseCLI: Sendable {
                 ),
                 exitCode: 1
             ).render()
+        }
+    }
+
+    private func executeUITree(
+        _ options: UITreeOptions,
+        json: Bool
+    ) -> CLIResult {
+        do {
+            let payload = try PlayCoverUITreeService.run(
+                options: options,
+                paths: paths
+            )
+            if json {
+                return MachineOutput.success(
+                    command: "ui-tree",
+                    data: PlayCoverUITreeService.machineData(payload)
+                )
+            }
+            return CLIResult(
+                exitCode: 0,
+                stdout: PlayCoverUITreeService.format(payload)
+            )
+        } catch {
+            return commandFailure(
+                command: "ui-tree",
+                error: error,
+                json: json
+            )
         }
     }
 

--- a/swift-cli/Tests/IOSUseCLITests/CLIParserTests.swift
+++ b/swift-cli/Tests/IOSUseCLITests/CLIParserTests.swift
@@ -140,6 +140,55 @@ final class CLIParserTests: XCTestCase {
         )
     }
 
+    func testParsesMacUITreeOptionsAndGlobalJSON() throws {
+        XCTAssertEqual(
+            try CLIParser.parse(["ui-tree"]),
+            .uiTree(UITreeOptions())
+        )
+        XCTAssertEqual(
+            try CLIParser.parseInvocation([
+                "ui-tree",
+                "--target",
+                "导入照片",
+                "--depth",
+                "12",
+                "--json",
+            ]),
+            ParsedInvocation(
+                command: .uiTree(
+                    UITreeOptions(target: "导入照片", depth: 12)
+                ),
+                json: true
+            )
+        )
+    }
+
+    func testRejectsInvalidMacUITreeOptions() {
+        let invalidCases: [([String], CLIParseError)] = [
+            (
+                ["ui-tree", "--depth", "-1"],
+                .invalidValue("--depth must be between 0 and 20")
+            ),
+            (
+                ["ui-tree", "--depth", "21"],
+                .invalidValue("--depth must be between 0 and 20")
+            ),
+            (
+                ["ui-tree", "--target", "   "],
+                .invalidValue("--target cannot be empty")
+            ),
+            (
+                ["ui-tree", "unexpected"],
+                .unknownOption("unexpected")
+            ),
+        ]
+        for (arguments, expected) in invalidCases {
+            XCTAssertThrowsError(try CLIParser.parse(arguments)) { error in
+                XCTAssertEqual(error as? CLIParseError, expected)
+            }
+        }
+    }
+
     func testRejectsMacSignerConfigurationMixedWithDeviceOptions() {
         let conflictingArguments: [[String]] = [
             ["--udid", "REAL-1"],

--- a/swift-cli/Tests/IOSUseCLITests/IOSUseCLITests.swift
+++ b/swift-cli/Tests/IOSUseCLITests/IOSUseCLITests.swift
@@ -518,6 +518,7 @@ final class IOSUseCLITests: XCTestCase {
             (["start", "--help"], "Usage: ios-use start"),
             (["stop", "--help"], "Usage: ios-use stop"),
             (["dom", "--help"], "Usage: ios-use dom"),
+            (["ui-tree", "--help"], "Usage: ios-use ui-tree"),
             (["waitFor", "--help"], "Usage: ios-use waitFor"),
             (["screenshot", "--help"], "Usage: ios-use screenshot"),
             (["capture", "--help"], "Usage: ios-use capture"),

--- a/swift-cli/Tests/IOSUseCLITests/PlayCover/PlayCoverCoreTests.swift
+++ b/swift-cli/Tests/IOSUseCLITests/PlayCover/PlayCoverCoreTests.swift
@@ -1090,7 +1090,7 @@ final class PlayCoverCoreTests: XCTestCase {
         )
         let pid: Int32 = 42
         let capabilities = [
-            "hello", "ping", "diagnostics", "screenshot", "dom",
+            "hello", "ping", "diagnostics", "screenshot", "dom", "uiTree",
             "waitFor", "tap", "longPress", "swipe", "input",
             "dismissAlert", "dismissAlertByLabel", "open",
         ]

--- a/swift-cli/Tests/IOSUseCLITests/PlayCover/PlayCoverDriverClientTests.swift
+++ b/swift-cli/Tests/IOSUseCLITests/PlayCover/PlayCoverDriverClientTests.swift
@@ -2386,6 +2386,10 @@ final class PlayCoverDriverClientTests: XCTestCase {
                 preconditionFailure("missing DOM test payload")
             }
             return .dom(dom)
+        case .uiTree:
+            preconditionFailure(
+                "uiTree is not routed through DriverCommandClient"
+            )
         case .waitFor:
             guard let waitFor else {
                 preconditionFailure("missing waitFor test payload")

--- a/swift-cli/Tests/IOSUseCLITests/PlayCover/PlayCoverRuntimeClientTests.swift
+++ b/swift-cli/Tests/IOSUseCLITests/PlayCover/PlayCoverRuntimeClientTests.swift
@@ -1365,16 +1365,11 @@ final class PlayCoverRuntimeClientTests: XCTestCase {
         case .uiTree:
             return [
                 "uiTree": [
-                    "source": "uikit-view-hierarchy",
                     "target": "Continue",
                     "maxDepth": 6,
                     "nodeCount": 1,
                     "truncated": false,
                     "roots": [[
-                        "nodeID": "v0",
-                        "path": [0],
-                        "depth": 0,
-                        "index": 0,
                         "childCount": 0,
                         "class": "UILabel",
                         "viewControllerClass": NSNull(),

--- a/swift-cli/Tests/IOSUseCLITests/PlayCover/PlayCoverRuntimeClientTests.swift
+++ b/swift-cli/Tests/IOSUseCLITests/PlayCover/PlayCoverRuntimeClientTests.swift
@@ -67,6 +67,22 @@ final class PlayCoverRuntimeClientTests: XCTestCase {
         XCTAssertNil(object["fromTarget"])
     }
 
+    func testUITreeEncodingKeepsExplicitNullTarget() throws {
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(
+                with: JSONEncoder().encode(
+                    PlayCoverRuntimeUITreeArguments(
+                        target: nil,
+                        depth: 8
+                    )
+                )
+            ) as? [String: Any]
+        )
+
+        XCTAssertTrue(object["target"] is NSNull)
+        XCTAssertEqual(object["depth"] as? Int, 8)
+    }
+
     func testEveryCommandUsesExactSingleSessionEnvelopeAndTypedPayload()
         throws
     {
@@ -93,6 +109,14 @@ final class PlayCoverRuntimeClientTests: XCTestCase {
                         $0["waitQuiescence"] as? Bool,
                         true
                     )
+                }
+            ),
+            (
+                .uiTree,
+                .uiTree(.init(target: "Continue", depth: 6)),
+                {
+                    XCTAssertEqual($0["target"] as? String, "Continue")
+                    XCTAssertEqual($0["depth"] as? Int, 6)
                 }
             ),
             (
@@ -1338,6 +1362,51 @@ final class PlayCoverRuntimeClientTests: XCTestCase {
             ]
         case .dom:
             return ["dom": domPayload(generation: 1)]
+        case .uiTree:
+            return [
+                "uiTree": [
+                    "source": "uikit-view-hierarchy",
+                    "target": "Continue",
+                    "maxDepth": 6,
+                    "nodeCount": 1,
+                    "truncated": false,
+                    "roots": [[
+                        "nodeID": "v0",
+                        "path": [0],
+                        "depth": 0,
+                        "index": 0,
+                        "childCount": 0,
+                        "class": "UILabel",
+                        "viewControllerClass": NSNull(),
+                        "frame": [
+                            "x": 1,
+                            "y": 2,
+                            "width": 100,
+                            "height": 30,
+                        ],
+                        "bounds": [
+                            "x": 0,
+                            "y": 0,
+                            "width": 100,
+                            "height": 30,
+                        ],
+                        "hidden": false,
+                        "alpha": 1,
+                        "userInteractionEnabled": false,
+                        "clipsToBounds": false,
+                        "contentMode": "scaleToFill",
+                        "accessibilityIdentifier": NSNull(),
+                        "accessibilityLabel": "Continue",
+                        "layout": [
+                            "ambiguous": false,
+                            "translatesAutoresizingMaskIntoConstraints": false,
+                            "constraintCount": 1,
+                        ],
+                        "properties": ["text": "Continue"],
+                        "subviews": [],
+                    ]],
+                ],
+            ]
         case .waitFor:
             return [
                 "waitFor": [
@@ -1607,6 +1676,7 @@ private extension PlayCoverRuntimeCommand {
         .diagnostics,
         .screenshot,
         .dom,
+        .uiTree,
         .waitFor,
         .tap,
         .longPress,

--- a/swift-cli/Tests/IOSUseCLITests/PlayCover/PlayCoverUITreeServiceTests.swift
+++ b/swift-cli/Tests/IOSUseCLITests/PlayCover/PlayCoverUITreeServiceTests.swift
@@ -42,10 +42,6 @@ final class PlayCoverUITreeServiceTests: XCTestCase {
 
     func testHumanAndMachineOutputKeepHierarchyAndUsefulProperties() throws {
         let child = makeNode(
-            id: "v0.0",
-            path: [0, 0],
-            depth: 1,
-            index: 0,
             className: "UILabel",
             label: "导入照片",
             properties: [
@@ -54,25 +50,16 @@ final class PlayCoverUITreeServiceTests: XCTestCase {
             ]
         )
         let image = makeNode(
-            id: "v0.1",
-            path: [0, 1],
-            depth: 1,
-            index: 1,
             className: "UIImageView",
             clipsToBounds: true,
             contentMode: "scaleAspectFill",
             properties: ["image": .null]
         )
         let root = makeNode(
-            id: "v0",
-            path: [0],
-            depth: 0,
-            index: 0,
             className: "UIView",
             subviews: [child, image]
         )
         let payload = PlayCoverRuntimeUITreePayload(
-            source: "uikit-view-hierarchy",
             target: "导入照片",
             maxDepth: 8,
             nodeCount: 3,
@@ -83,8 +70,9 @@ final class PlayCoverUITreeServiceTests: XCTestCase {
         let text = PlayCoverUITreeService.format(payload)
         XCTAssertTrue(text.contains("UIKit view tree · 3 nodes"))
         XCTAssertTrue(text.contains("Target: 导入照片"))
-        XCTAssertTrue(text.contains("└─ UIView v0"))
-        XCTAssertTrue(text.contains("UILabel v0.0"))
+        XCTAssertTrue(text.contains("└─ UIView frame="))
+        XCTAssertTrue(text.contains("├─ UILabel frame="))
+        XCTAssertFalse(text.contains(" v0"))
         XCTAssertTrue(text.contains("fontSize=18"))
         XCTAssertTrue(text.contains("contentMode=scaleAspectFill"))
         XCTAssertTrue(text.contains(" clips"))
@@ -95,7 +83,6 @@ final class PlayCoverUITreeServiceTests: XCTestCase {
             JSONSerialization.jsonObject(with: encoded)
                 as? [String: Any]
         )
-        XCTAssertEqual(object["source"] as? String, "uikit-view-hierarchy")
         XCTAssertEqual(object["nodeCount"] as? Int, 3)
         let roots = try XCTUnwrap(object["roots"] as? [[String: Any]])
         let subviews = try XCTUnwrap(
@@ -108,7 +95,6 @@ final class PlayCoverUITreeServiceTests: XCTestCase {
 
     func testHumanOutputSurfacesTruncation() {
         let payload = PlayCoverRuntimeUITreePayload(
-            source: "uikit-view-hierarchy",
             target: nil,
             maxDepth: 0,
             nodeCount: 1,
@@ -124,9 +110,6 @@ final class PlayCoverUITreeServiceTests: XCTestCase {
 
     func testHumanOutputPrintsViewControllerOnlyWhenItChanges() {
         let child = makeNode(
-            id: "v0.0",
-            path: [0, 0],
-            depth: 1,
             viewControllerClass: "FixtureViewController"
         )
         let root = makeNode(
@@ -134,7 +117,6 @@ final class PlayCoverUITreeServiceTests: XCTestCase {
             subviews: [child]
         )
         let payload = PlayCoverRuntimeUITreePayload(
-            source: "uikit-view-hierarchy",
             target: nil,
             maxDepth: 8,
             nodeCount: 2,
@@ -150,10 +132,6 @@ final class PlayCoverUITreeServiceTests: XCTestCase {
     }
 
     private func makeNode(
-        id: String = "v0",
-        path: [Int] = [0],
-        depth: Int = 0,
-        index: Int = 0,
         className: String = "UIView",
         viewControllerClass: String? = nil,
         label: String? = nil,
@@ -163,10 +141,6 @@ final class PlayCoverUITreeServiceTests: XCTestCase {
         subviews: [PlayCoverRuntimeUITreeNode] = []
     ) -> PlayCoverRuntimeUITreeNode {
         PlayCoverRuntimeUITreeNode(
-            nodeID: id,
-            path: path,
-            depth: depth,
-            index: index,
             childCount: subviews.count,
             class: className,
             viewControllerClass: viewControllerClass,

--- a/swift-cli/Tests/IOSUseCLITests/PlayCover/PlayCoverUITreeServiceTests.swift
+++ b/swift-cli/Tests/IOSUseCLITests/PlayCover/PlayCoverUITreeServiceTests.swift
@@ -1,0 +1,191 @@
+import XCTest
+@testable import IOSUseCLI
+
+final class PlayCoverUITreeServiceTests: XCTestCase {
+    func testRunRejectsAnActiveNonMacSessionBeforeRuntimeWork() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "ios-use-ui-tree-non-mac-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        defer { try? FileManager.default.removeItem(at: root) }
+        let paths = IOSUsePaths.resolve(
+            environment: ["IOS_USE_HOME": root.path]
+        )
+        try SessionService.writeDriverLock(
+            info: SessionService.Info(
+                udid: "REAL-DEVICE",
+                deviceName: "iPhone",
+                deviceVersion: "18.0",
+                deviceType: "real"
+            ),
+            paths: paths
+        )
+
+        XCTAssertThrowsError(
+            try PlayCoverUITreeService.run(
+                options: UITreeOptions(),
+                paths: paths
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? PlayCoverUITreeService.Error,
+                .requiresMacSession
+            )
+            XCTAssertEqual(
+                (error as? PlayCoverUITreeService.Error)?
+                    .machineError.code,
+                "mac_session_required"
+            )
+        }
+    }
+
+    func testHumanAndMachineOutputKeepHierarchyAndUsefulProperties() throws {
+        let child = makeNode(
+            id: "v0.0",
+            path: [0, 0],
+            depth: 1,
+            index: 0,
+            className: "UILabel",
+            label: "导入照片",
+            properties: [
+                "text": .string("导入照片"),
+                "fontSize": .number(18),
+            ]
+        )
+        let image = makeNode(
+            id: "v0.1",
+            path: [0, 1],
+            depth: 1,
+            index: 1,
+            className: "UIImageView",
+            clipsToBounds: true,
+            contentMode: "scaleAspectFill",
+            properties: ["image": .null]
+        )
+        let root = makeNode(
+            id: "v0",
+            path: [0],
+            depth: 0,
+            index: 0,
+            className: "UIView",
+            subviews: [child, image]
+        )
+        let payload = PlayCoverRuntimeUITreePayload(
+            source: "uikit-view-hierarchy",
+            target: "导入照片",
+            maxDepth: 8,
+            nodeCount: 3,
+            truncated: false,
+            roots: [root]
+        )
+
+        let text = PlayCoverUITreeService.format(payload)
+        XCTAssertTrue(text.contains("UIKit view tree · 3 nodes"))
+        XCTAssertTrue(text.contains("Target: 导入照片"))
+        XCTAssertTrue(text.contains("└─ UIView v0"))
+        XCTAssertTrue(text.contains("UILabel v0.0"))
+        XCTAssertTrue(text.contains("fontSize=18"))
+        XCTAssertTrue(text.contains("contentMode=scaleAspectFill"))
+        XCTAssertTrue(text.contains(" clips"))
+
+        let machine = PlayCoverUITreeService.machineData(payload)
+        let encoded = try JSONEncoder().encode(machine)
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: encoded)
+                as? [String: Any]
+        )
+        XCTAssertEqual(object["source"] as? String, "uikit-view-hierarchy")
+        XCTAssertEqual(object["nodeCount"] as? Int, 3)
+        let roots = try XCTUnwrap(object["roots"] as? [[String: Any]])
+        let subviews = try XCTUnwrap(
+            roots[0]["subviews"] as? [[String: Any]]
+        )
+        XCTAssertEqual(subviews[0]["class"] as? String, "UILabel")
+        XCTAssertNil(subviews[0]["address"])
+        XCTAssertEqual(subviews[1]["class"] as? String, "UIImageView")
+    }
+
+    func testHumanOutputSurfacesTruncation() {
+        let payload = PlayCoverRuntimeUITreePayload(
+            source: "uikit-view-hierarchy",
+            target: nil,
+            maxDepth: 0,
+            nodeCount: 1,
+            truncated: true,
+            roots: [makeNode()]
+        )
+
+        XCTAssertTrue(
+            PlayCoverUITreeService.format(payload)
+                .contains("output truncated by the depth or node limit")
+        )
+    }
+
+    func testHumanOutputPrintsViewControllerOnlyWhenItChanges() {
+        let child = makeNode(
+            id: "v0.0",
+            path: [0, 0],
+            depth: 1,
+            viewControllerClass: "FixtureViewController"
+        )
+        let root = makeNode(
+            viewControllerClass: "FixtureViewController",
+            subviews: [child]
+        )
+        let payload = PlayCoverRuntimeUITreePayload(
+            source: "uikit-view-hierarchy",
+            target: nil,
+            maxDepth: 8,
+            nodeCount: 2,
+            truncated: false,
+            roots: [root]
+        )
+
+        let text = PlayCoverUITreeService.format(payload)
+        XCTAssertEqual(
+            text.components(separatedBy: "vc=FixtureViewController").count - 1,
+            1
+        )
+    }
+
+    private func makeNode(
+        id: String = "v0",
+        path: [Int] = [0],
+        depth: Int = 0,
+        index: Int = 0,
+        className: String = "UIView",
+        viewControllerClass: String? = nil,
+        label: String? = nil,
+        clipsToBounds: Bool = false,
+        contentMode: String = "scaleToFill",
+        properties: [String: PlayCoverRuntimeJSONValue] = [:],
+        subviews: [PlayCoverRuntimeUITreeNode] = []
+    ) -> PlayCoverRuntimeUITreeNode {
+        PlayCoverRuntimeUITreeNode(
+            nodeID: id,
+            path: path,
+            depth: depth,
+            index: index,
+            childCount: subviews.count,
+            class: className,
+            viewControllerClass: viewControllerClass,
+            frame: .init(x: 1, y: 2, width: 100, height: 30),
+            bounds: .init(x: 0, y: 0, width: 100, height: 30),
+            hidden: false,
+            alpha: 1,
+            userInteractionEnabled: true,
+            clipsToBounds: clipsToBounds,
+            contentMode: contentMode,
+            accessibilityIdentifier: nil,
+            accessibilityLabel: label,
+            layout: .init(
+                ambiguous: false,
+                translatesAutoresizingMaskIntoConstraints: false,
+                constraintCount: 0
+            ),
+            properties: properties,
+            subviews: subviews
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- add a Mac-only `ios-use ui-tree` command for bounded, read-only UIKit hierarchy inspection
- support semantic target scoping plus class, geometry, accessibility, layout, and selected public view properties
- keep DOM as the interaction surface and document the diagnostic boundary
- keep output focused: no snapshot-local node IDs, paths, addresses, registries, or constant source markers

The PR now targets `main` directly. It does not publish or tag 2.0.0.

## Validation

- Swift CLI general: 429 tests, 3 skipped, 0 failures
- Swift CLI Mac: 313 tests, 2 skipped, 0 failures
- prepare differential: 18/18 passed
- deterministic Runtime contracts passed, including the view-tree contract
- Runtime and CLI builds passed
- release workflow contract and installed-layout `--verify-only` passed
- local release candidate checksums: 15/15 passed
- latest Retouch Debug App: installed release candidate start / ui-tree / stop passed in an isolated Home
- observed query latency: 20–90 ms across a target subtree and a bounded depth-8 tree; output contained no snapshot-local IDs
