### PR TITLE
fix(mac): build runtime with Xcode 26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,18 @@ jobs:
           node --check scripts/ios_use_test_simulator.js
           node --check scripts/test_simulator_commands.mjs
 
+  mac-runtime-build:
+    runs-on: macos-26
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install xcodegen
+        run: brew install xcodegen
+
+      - name: Build Mac Runtime
+        run: bash scripts/build_playcover_runtime.sh --output "$RUNNER_TEMP/IOSUsePlayRuntime.framework"
+
   swift-cli-tests:
     runs-on: macos-26
     timeout-minutes: 20

--- a/playcover-runtime/IOSUsePlayAppKitBridge.m
+++ b/playcover-runtime/IOSUsePlayAppKitBridge.m
@@ -12,6 +12,11 @@
 #import <string.h>
 #import <unistd.h>
 
+static const CGFloat IOSUseBridgeDeviceLogicalWidth =
+    (CGFloat)IOSUsePlayDeviceLogicalWidth;
+static const CGFloat IOSUseBridgeDeviceLogicalHeight =
+    (CGFloat)IOSUsePlayDeviceLogicalHeight;
+
 typedef id (*IOSUseBridgeSendID)(id, SEL);
 typedef id (*IOSUseBridgeSendIDInteger)(id, SEL, NSInteger);
 typedef BOOL (*IOSUseBridgeSendBool)(id, SEL);
@@ -654,9 +659,9 @@ static CGFloat IOSUseBridgeBackingScaleFactor(id window) {
 
 static CGSize IOSUseBridgeHostMinimumContentSize(void) {
     return CGSizeMake(
-        IOSUsePlayDeviceLogicalWidth *
+        IOSUseBridgeDeviceLogicalWidth *
             IOSUsePlayHostCanvasMinimumDisplayScale,
-        IOSUsePlayDeviceLogicalHeight *
+        IOSUseBridgeDeviceLogicalHeight *
             IOSUsePlayHostCanvasMinimumDisplayScale
     );
 }

--- a/playcover-runtime/IOSUsePlayRuntimeAutomation.m
+++ b/playcover-runtime/IOSUsePlayRuntimeAutomation.m
@@ -15,6 +15,10 @@ static const NSTimeInterval IOSUseAutomationMainTimeout = 40.0;
 static const NSUInteger IOSUseAutomationMaximumSemanticScrolls = 25;
 static const CGFloat IOSUseAutomationScrollProportion = 0.75;
 static const CGFloat IOSUseAutomationScrollEpsilon = 0.5;
+static const CGFloat IOSUseAutomationDeviceLogicalWidth =
+    (CGFloat)IOSUsePlayDeviceLogicalWidth;
+static const CGFloat IOSUseAutomationDeviceLogicalHeight =
+    (CGFloat)IOSUsePlayDeviceLogicalHeight;
 
 NSTimeInterval IOSUsePlayRuntimeAutomationMainThreadTimeout(void) {
     return IOSUseAutomationMainTimeout;
@@ -88,8 +92,8 @@ static BOOL IOSUseAutomationIsNumber(id value) {
 static BOOL IOSUseAutomationFinitePoint(CGPoint point) {
     return isfinite(point.x) && isfinite(point.y) &&
         point.x >= 0 && point.y >= 0 &&
-        point.x <= IOSUsePlayDeviceLogicalWidth &&
-        point.y <= IOSUsePlayDeviceLogicalHeight;
+        point.x <= IOSUseAutomationDeviceLogicalWidth &&
+        point.y <= IOSUseAutomationDeviceLogicalHeight;
 }
 
 static NSDictionary<NSString *, id> *
@@ -2488,8 +2492,8 @@ static NSDictionary<NSString *, id> *IOSUseAutomationTouchCommand(
             @"label": @"",
             @"traits": @"",
             @"point": @{
-                @"x": @(IOSUsePlayDeviceLogicalWidth / 2.0),
-                @"y": @(IOSUsePlayDeviceLogicalHeight / 2.0),
+                @"x": @(IOSUseAutomationDeviceLogicalWidth / 2.0),
+                @"y": @(IOSUseAutomationDeviceLogicalHeight / 2.0),
             },
         };
     }

--- a/playcover-runtime/IOSUsePlayRuntimeScreenshot.m
+++ b/playcover-runtime/IOSUsePlayRuntimeScreenshot.m
@@ -14,6 +14,16 @@ static const NSUInteger IOSUseScreenshotMaximumJPEGBytes = 11 * 1024 * 1024;
 static const NSUInteger IOSUseScreenshotMaximumBase64Bytes =
     15 * 1024 * 1024;
 static const CGFloat IOSUseScreenshotGeometryTolerance = 0.01;
+static const CGFloat IOSUseScreenshotDeviceLogicalWidth =
+    (CGFloat)IOSUsePlayDeviceLogicalWidth;
+static const CGFloat IOSUseScreenshotDeviceLogicalHeight =
+    (CGFloat)IOSUsePlayDeviceLogicalHeight;
+static const CGFloat IOSUseScreenshotDeviceScale =
+    (CGFloat)IOSUsePlayDeviceScale;
+static const CGBitmapInfo IOSUseScreenshotBitmapInfo = (CGBitmapInfo)(
+    (uint32_t)kCGBitmapByteOrder32Little |
+    (uint32_t)kCGImageAlphaPremultipliedFirst
+);
 static atomic_bool IOSUseScreenshotInFlight = false;
 static atomic_ullong IOSUseScreenshotCaptureGeneration = 0;
 
@@ -96,8 +106,8 @@ static NSDictionary<NSString *, id> *IOSUseScreenshotFullFrameEvidence(
     CGRect deviceFrame = CGRectMake(
         0,
         0,
-        IOSUsePlayDeviceLogicalWidth,
-        IOSUsePlayDeviceLogicalHeight
+        IOSUseScreenshotDeviceLogicalWidth,
+        IOSUseScreenshotDeviceLogicalHeight
     );
     return @{
         @"logicalRect": IOSUseScreenshotRectJSON(deviceFrame),
@@ -167,11 +177,11 @@ static BOOL IOSUseScreenshotRectIsDeviceSize(CGRect rect) {
     return IOSUseScreenshotFiniteRect(rect) &&
         IOSUseScreenshotApproximatelyEqual(
             rect.size.width,
-            IOSUsePlayDeviceLogicalWidth
+            IOSUseScreenshotDeviceLogicalWidth
         ) &&
         IOSUseScreenshotApproximatelyEqual(
             rect.size.height,
-            IOSUsePlayDeviceLogicalHeight
+            IOSUseScreenshotDeviceLogicalHeight
         );
 }
 
@@ -184,10 +194,10 @@ static BOOL IOSUseScreenshotLogicalRectIsInsideDevice(CGRect rect) {
         CGRectGetMinY(rect) >=
             -IOSUseScreenshotGeometryTolerance &&
         CGRectGetMaxX(rect) <=
-            IOSUsePlayDeviceLogicalWidth +
+            IOSUseScreenshotDeviceLogicalWidth +
                 IOSUseScreenshotGeometryTolerance &&
         CGRectGetMaxY(rect) <=
-            IOSUsePlayDeviceLogicalHeight +
+            IOSUseScreenshotDeviceLogicalHeight +
                 IOSUseScreenshotGeometryTolerance;
 }
 
@@ -1099,8 +1109,7 @@ static BOOL IOSUseScreenshotHasUsablePixels(CGImageRef image) {
         8,
         rowBytes,
         colorSpace,
-        kCGBitmapByteOrder32Little |
-            kCGImageAlphaPremultipliedFirst
+        IOSUseScreenshotBitmapInfo
     );
     CGColorSpaceRelease(colorSpace);
     if (context == NULL) {
@@ -1580,7 +1589,7 @@ static CGImageRef IOSUseScreenshotCaptureFrameOnMain(
             .appKitFrame = window.deviceLogicalRect,
             .deviceLogicalRect =
                 window.deviceLogicalRect,
-            .backingScale = IOSUsePlayDeviceScale,
+            .backingScale = IOSUseScreenshotDeviceScale,
             .windowNumber = window.windowNumber,
         };
     }
@@ -1672,7 +1681,7 @@ IOSUseScreenshotPayloadOnMain(
         return nil;
     }
     UIImage *uiImage = [UIImage imageWithCGImage:image
-                                          scale:IOSUsePlayDeviceScale
+                                          scale:IOSUseScreenshotDeviceScale
                                     orientation:UIImageOrientationUp];
     CGImageRelease(image);
     NSData *jpeg = UIImageJPEGRepresentation(uiImage, 0.9);

--- a/playcover-runtime/IOSUsePlayRuntimeSocket.m
+++ b/playcover-runtime/IOSUsePlayRuntimeSocket.m
@@ -30,6 +30,18 @@
 static const NSUInteger IOSUseMaximumRequestFrameSize = 64 * 1024;
 static const NSUInteger IOSUseMaximumResponseFrameSize = 16 * 1024 * 1024;
 static const NSTimeInterval IOSUseSocketIOTimeoutSeconds = 15;
+static const CGFloat IOSUseRuntimeDeviceLogicalWidth =
+    (CGFloat)IOSUsePlayDeviceLogicalWidth;
+static const CGFloat IOSUseRuntimeDeviceLogicalHeight =
+    (CGFloat)IOSUsePlayDeviceLogicalHeight;
+static const CGFloat IOSUseRuntimeDeviceNativeWidth =
+    (CGFloat)IOSUsePlayDeviceNativeWidth;
+static const CGFloat IOSUseRuntimeDeviceNativeHeight =
+    (CGFloat)IOSUsePlayDeviceNativeHeight;
+static const CGFloat IOSUseRuntimeDeviceScale =
+    (CGFloat)IOSUsePlayDeviceScale;
+static const CGFloat IOSUseRuntimeDeviceSafeAreaTop =
+    (CGFloat)IOSUsePlayDeviceSafeAreaTop;
 
 static NSString *IOSUseRuntimeSessionID;
 static NSString *IOSUseRuntimeSocketPath;
@@ -655,9 +667,9 @@ static BOOL IOSUseSocketMatchesFixedLogicalCanvas(
 ) {
     return fabs(rect.origin.x) <= originTolerance &&
         fabs(rect.origin.y) <= originTolerance &&
-        fabs(rect.size.width - IOSUsePlayDeviceLogicalWidth) <=
+        fabs(rect.size.width - IOSUseRuntimeDeviceLogicalWidth) <=
             sizeTolerance &&
-        fabs(rect.size.height - IOSUsePlayDeviceLogicalHeight) <=
+        fabs(rect.size.height - IOSUseRuntimeDeviceLogicalHeight) <=
             sizeTolerance;
 }
 
@@ -673,13 +685,13 @@ static BOOL IOSUseSocketMatchesPixelQuantizedPrivateCanvas(
     // host over a few millionths of one logical point.
     const CGFloat quantizationEpsilon = 0.00001;
     CGFloat widthDelta =
-        rect.size.width - IOSUsePlayDeviceLogicalWidth;
+        rect.size.width - IOSUseRuntimeDeviceLogicalWidth;
     CGFloat heightDelta =
-        rect.size.height - IOSUsePlayDeviceLogicalHeight;
+        rect.size.height - IOSUseRuntimeDeviceLogicalHeight;
     CGFloat maximumXDelta =
-        CGRectGetMaxX(rect) - IOSUsePlayDeviceLogicalWidth;
+        CGRectGetMaxX(rect) - IOSUseRuntimeDeviceLogicalWidth;
     CGFloat maximumYDelta =
-        CGRectGetMaxY(rect) - IOSUsePlayDeviceLogicalHeight;
+        CGRectGetMaxY(rect) - IOSUseRuntimeDeviceLogicalHeight;
     return fabs(rect.origin.x) <= originTolerance &&
         fabs(rect.origin.y) <= originTolerance &&
         widthDelta >= -originTolerance &&
@@ -854,9 +866,9 @@ static BOOL IOSUseHostGeometryReady(NSDictionary<NSString *, id> *host) {
         fabs(displayScale * inverseDisplayScale - 1.0) <= 0.01 &&
         fabs(canvasBounds.origin.x) <= logicalEdgeTolerance &&
         fabs(canvasBounds.origin.y) <= logicalEdgeTolerance &&
-        fabs(canvasBounds.size.width - IOSUsePlayDeviceLogicalWidth) <=
+        fabs(canvasBounds.size.width - IOSUseRuntimeDeviceLogicalWidth) <=
             logicalEdgeTolerance &&
-        fabs(canvasBounds.size.height - IOSUsePlayDeviceLogicalHeight) <=
+        fabs(canvasBounds.size.height - IOSUseRuntimeDeviceLogicalHeight) <=
             logicalEdgeTolerance &&
         IOSUseSocketMatchesFixedLogicalCanvas(
             renderViewBounds,
@@ -918,9 +930,9 @@ static BOOL IOSUseHostGeometryReady(NSDictionary<NSString *, id> *host) {
         fabs(leftMargin - rightMargin) <= halfPixelTolerance &&
         fabs(bottomMargin - topMargin) <= halfPixelTolerance &&
         fabs(canvasRect.size.width / displayScale -
-            IOSUsePlayDeviceLogicalWidth) <= logicalTolerance &&
+            IOSUseRuntimeDeviceLogicalWidth) <= logicalTolerance &&
         fabs(canvasRect.size.height / displayScale -
-            IOSUsePlayDeviceLogicalHeight) <= logicalTolerance &&
+            IOSUseRuntimeDeviceLogicalHeight) <= logicalTolerance &&
         IOSUseSocketRectFromJSON(
             capture[@"hostContentCGWindowRect"],
             &hostContentCGWindowRect
@@ -1049,10 +1061,10 @@ static NSDictionary<NSString *, id> *IOSUseRuntimeSnapshot(
             statusBarManager != nil &&
             isfinite(statusBarFrame.size.height) &&
             statusBarFrame.size.height ==
-                IOSUsePlayDeviceSafeAreaTop &&
+                IOSUseRuntimeDeviceSafeAreaTop &&
             isfinite(applicationStatusBarFrame.size.height) &&
             applicationStatusBarFrame.size.height ==
-                IOSUsePlayDeviceSafeAreaTop;
+                IOSUseRuntimeDeviceSafeAreaTop;
         NSString *deviceModel = device.model ?: @"";
         NSString *localizedDeviceModel = device.localizedModel ?: @"";
         BOOL deviceIdentityReady =
@@ -1071,7 +1083,7 @@ static NSDictionary<NSString *, id> *IOSUseRuntimeSnapshot(
             deviceOrientation ==
                 (UIDeviceOrientation)IOSUsePlayDeviceOrientation &&
             sceneOrientation == UIInterfaceOrientationPortrait &&
-            nativeScale == IOSUsePlayDeviceScale &&
+            nativeScale == IOSUseRuntimeDeviceScale &&
             statusBarReady;
         hooks = IOSUsePlayRuntimeHookDiagnostics(
             scope,
@@ -1180,19 +1192,19 @@ static NSDictionary<NSString *, id> *IOSUseRuntimeSnapshot(
         };
         BOOL exact =
             fabs(logical.size.width -
-                IOSUsePlayDeviceLogicalWidth) <= 0.01 &&
+                IOSUseRuntimeDeviceLogicalWidth) <= 0.01 &&
             fabs(logical.size.height -
-                IOSUsePlayDeviceLogicalHeight) <= 0.01 &&
+                IOSUseRuntimeDeviceLogicalHeight) <= 0.01 &&
             fabs(native.size.width -
-                IOSUsePlayDeviceNativeWidth) <= 0.01 &&
+                IOSUseRuntimeDeviceNativeWidth) <= 0.01 &&
             fabs(native.size.height -
-                IOSUsePlayDeviceNativeHeight) <= 0.01 &&
-            fabs(screenScale - IOSUsePlayDeviceScale) <= 0.01 &&
-            fabs(nativeScale - IOSUsePlayDeviceScale) <= 0.01 &&
+                IOSUseRuntimeDeviceNativeHeight) <= 0.01 &&
+            fabs(screenScale - IOSUseRuntimeDeviceScale) <= 0.01 &&
+            fabs(nativeScale - IOSUseRuntimeDeviceScale) <= 0.01 &&
             fabs(windowBounds.size.width -
-                IOSUsePlayDeviceLogicalWidth) <= 0.01 &&
+                IOSUseRuntimeDeviceLogicalWidth) <= 0.01 &&
             fabs(windowBounds.size.height -
-                IOSUsePlayDeviceLogicalHeight) <= 0.01 &&
+                IOSUseRuntimeDeviceLogicalHeight) <= 0.01 &&
             deviceIdentityReady &&
             requiredHooksReady &&
             [hooks[@"configurationStage"]

--- a/playcover-runtime/IOSUsePlayWindowCompositor.m
+++ b/playcover-runtime/IOSUsePlayWindowCompositor.m
@@ -8,6 +8,16 @@
 typedef id (*IOSUseCompositorSendID)(id, SEL);
 
 static const CGFloat IOSUseCompositorGeometryTolerance = 0.01;
+static const CGFloat IOSUseCompositorDeviceLogicalWidth =
+    (CGFloat)IOSUsePlayDeviceLogicalWidth;
+static const CGFloat IOSUseCompositorDeviceLogicalHeight =
+    (CGFloat)IOSUsePlayDeviceLogicalHeight;
+static const CGFloat IOSUseCompositorDeviceScale =
+    (CGFloat)IOSUsePlayDeviceScale;
+static const CGBitmapInfo IOSUseCompositorBitmapInfo = (CGBitmapInfo)(
+    (uint32_t)kCGBitmapByteOrder32Little |
+    (uint32_t)kCGImageAlphaPremultipliedFirst
+);
 
 CGFloat const IOSUsePlayHostCanvasMinimumDisplayScale = 0.5;
 
@@ -194,10 +204,10 @@ BOOL IOSUsePlayResolveHostCanvasLayout(
     CGFloat halfPixelTolerance =
         IOSUseCompositorHalfPixelTolerance(backingScaleFactor);
     CGFloat minimumWidth =
-        IOSUsePlayDeviceLogicalWidth *
+        IOSUseCompositorDeviceLogicalWidth *
         IOSUsePlayHostCanvasMinimumDisplayScale;
     CGFloat minimumHeight =
-        IOSUsePlayDeviceLogicalHeight *
+        IOSUseCompositorDeviceLogicalHeight *
         IOSUsePlayHostCanvasMinimumDisplayScale;
     if (hostContentBounds.size.width < minimumWidth ||
         hostContentBounds.size.height < minimumHeight) {
@@ -214,8 +224,8 @@ BOOL IOSUsePlayResolveHostCanvasLayout(
         return NO;
     }
     CGFloat displayScale = MIN(
-        hostContentBounds.size.width / IOSUsePlayDeviceLogicalWidth,
-        hostContentBounds.size.height / IOSUsePlayDeviceLogicalHeight
+        hostContentBounds.size.width / IOSUseCompositorDeviceLogicalWidth,
+        hostContentBounds.size.height / IOSUseCompositorDeviceLogicalHeight
     );
     if (!isfinite(displayScale) ||
         displayScale < IOSUsePlayHostCanvasMinimumDisplayScale) {
@@ -225,8 +235,8 @@ BOOL IOSUsePlayResolveHostCanvasLayout(
         return NO;
     }
     CGSize canvasSize = CGSizeMake(
-        IOSUsePlayDeviceLogicalWidth * displayScale,
-        IOSUsePlayDeviceLogicalHeight * displayScale
+        IOSUseCompositorDeviceLogicalWidth * displayScale,
+        IOSUseCompositorDeviceLogicalHeight * displayScale
     );
     CGRect canvasRect = CGRectMake(
         hostContentBounds.origin.x +
@@ -424,21 +434,21 @@ BOOL IOSUsePlayMapHostContentPointToCanvas(
     logical.x = IOSUseCompositorClampNearWithTolerance(
         logical.x,
         0,
-        IOSUsePlayDeviceLogicalWidth,
+        IOSUseCompositorDeviceLogicalWidth,
         logicalTolerance
     );
     logical.y = IOSUseCompositorClampNearWithTolerance(
         logical.y,
         0,
-        IOSUsePlayDeviceLogicalHeight,
+        IOSUseCompositorDeviceLogicalHeight,
         logicalTolerance
     );
     if (!IOSUseCompositorContainsPoint(
             CGRectMake(
                 0,
                 0,
-                IOSUsePlayDeviceLogicalWidth,
-                IOSUsePlayDeviceLogicalHeight
+                IOSUseCompositorDeviceLogicalWidth,
+                IOSUseCompositorDeviceLogicalHeight
             ),
             logical,
             YES
@@ -466,8 +476,8 @@ BOOL IOSUsePlayMapCanvasPointToHostContent(
     CGRect device = CGRectMake(
         0,
         0,
-        IOSUsePlayDeviceLogicalWidth,
-        IOSUsePlayDeviceLogicalHeight
+        IOSUseCompositorDeviceLogicalWidth,
+        IOSUseCompositorDeviceLogicalHeight
     );
     if (!IOSUseCompositorFiniteRect(layout.hostContentBounds) ||
         !IOSUseCompositorFiniteRect(layout.canvasRect) ||
@@ -591,25 +601,25 @@ BOOL IOSUsePlayMapHostContentRectToCanvas(
     CGFloat logicalMaximumX = IOSUseCompositorClampNearWithTolerance(
         CGRectGetMaxX(logical),
         0,
-        IOSUsePlayDeviceLogicalWidth,
+        IOSUseCompositorDeviceLogicalWidth,
         logicalTolerance
     );
     CGFloat logicalMaximumY = IOSUseCompositorClampNearWithTolerance(
         CGRectGetMaxY(logical),
         0,
-        IOSUsePlayDeviceLogicalHeight,
+        IOSUseCompositorDeviceLogicalHeight,
         logicalTolerance
     );
     logical.origin.x = IOSUseCompositorClampNearWithTolerance(
         logical.origin.x,
         0,
-        IOSUsePlayDeviceLogicalWidth,
+        IOSUseCompositorDeviceLogicalWidth,
         logicalTolerance
     );
     logical.origin.y = IOSUseCompositorClampNearWithTolerance(
         logical.origin.y,
         0,
-        IOSUsePlayDeviceLogicalHeight,
+        IOSUseCompositorDeviceLogicalHeight,
         logicalTolerance
     );
     logical.size.width = logicalMaximumX - logical.origin.x;
@@ -619,8 +629,8 @@ BOOL IOSUsePlayMapHostContentRectToCanvas(
             CGRectMake(
                 0,
                 0,
-                IOSUsePlayDeviceLogicalWidth,
-                IOSUsePlayDeviceLogicalHeight
+                IOSUseCompositorDeviceLogicalWidth,
+                IOSUseCompositorDeviceLogicalHeight
             ),
             logical,
             logicalTolerance
@@ -759,12 +769,12 @@ BOOL IOSUsePlayResolveCGWindowRectInCanvas(
     if (
         !IOSUseCompositorApproximatelyEqualWithTolerance(
             canvasCGWindowRect.size.width / displayScale,
-            IOSUsePlayDeviceLogicalWidth,
+            IOSUseCompositorDeviceLogicalWidth,
             logicalExtentTolerance
         ) ||
         !IOSUseCompositorApproximatelyEqualWithTolerance(
             canvasCGWindowRect.size.height / displayScale,
-            IOSUsePlayDeviceLogicalHeight,
+            IOSUseCompositorDeviceLogicalHeight,
             logicalExtentTolerance
         )) {
         if (failure != NULL) {
@@ -828,18 +838,18 @@ BOOL IOSUsePlayResolveCGWindowRectInCanvas(
         logical.origin.y = 0;
     }
     if (reachesCanvasMaximumX) {
-        logicalMaximumX = IOSUsePlayDeviceLogicalWidth;
-    } else if (logicalMaximumX > IOSUsePlayDeviceLogicalWidth &&
+        logicalMaximumX = IOSUseCompositorDeviceLogicalWidth;
+    } else if (logicalMaximumX > IOSUseCompositorDeviceLogicalWidth &&
         logicalMaximumX <=
-            IOSUsePlayDeviceLogicalWidth + logicalEdgeTolerance) {
-        logicalMaximumX = IOSUsePlayDeviceLogicalWidth;
+            IOSUseCompositorDeviceLogicalWidth + logicalEdgeTolerance) {
+        logicalMaximumX = IOSUseCompositorDeviceLogicalWidth;
     }
     if (reachesCanvasMaximumY) {
-        logicalMaximumY = IOSUsePlayDeviceLogicalHeight;
-    } else if (logicalMaximumY > IOSUsePlayDeviceLogicalHeight &&
+        logicalMaximumY = IOSUseCompositorDeviceLogicalHeight;
+    } else if (logicalMaximumY > IOSUseCompositorDeviceLogicalHeight &&
         logicalMaximumY <=
-            IOSUsePlayDeviceLogicalHeight + logicalEdgeTolerance) {
-        logicalMaximumY = IOSUsePlayDeviceLogicalHeight;
+            IOSUseCompositorDeviceLogicalHeight + logicalEdgeTolerance) {
+        logicalMaximumY = IOSUseCompositorDeviceLogicalHeight;
     }
     logical.size.width = logicalMaximumX - logical.origin.x;
     logical.size.height = logicalMaximumY - logical.origin.y;
@@ -848,8 +858,8 @@ BOOL IOSUsePlayResolveCGWindowRectInCanvas(
             CGRectMake(
                 0,
                 0,
-                IOSUsePlayDeviceLogicalWidth,
-                IOSUsePlayDeviceLogicalHeight
+                IOSUseCompositorDeviceLogicalWidth,
+                IOSUseCompositorDeviceLogicalHeight
             ),
             logical,
             logicalExtentTolerance
@@ -996,10 +1006,10 @@ CGImageRef IOSUsePlayCropAndNormalizeCanvasCapture(
         return NULL;
     }
     size_t normalizedWidth = (size_t)llround(
-        logical.size.width * IOSUsePlayDeviceScale
+        logical.size.width * IOSUseCompositorDeviceScale
     );
     size_t normalizedHeight = (size_t)llround(
-        logical.size.height * IOSUsePlayDeviceScale
+        logical.size.height * IOSUseCompositorDeviceScale
     );
     size_t rowBytes = normalizedWidth * 4;
     CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
@@ -1010,8 +1020,7 @@ CGImageRef IOSUsePlayCropAndNormalizeCanvasCapture(
         8,
         rowBytes,
         colorSpace,
-        kCGBitmapByteOrder32Little |
-            kCGImageAlphaPremultipliedFirst
+        IOSUseCompositorBitmapInfo
     );
     if (colorSpace != NULL) {
         CGColorSpaceRelease(colorSpace);
@@ -1401,8 +1410,8 @@ BOOL IOSUsePlayResolveLocalAppKitRect(
     CGRect logicalDevice = CGRectMake(
         0,
         0,
-        IOSUsePlayDeviceLogicalWidth,
-        IOSUsePlayDeviceLogicalHeight
+        IOSUseCompositorDeviceLogicalWidth,
+        IOSUseCompositorDeviceLogicalHeight
     );
     CGRect localWindow = CGRectMake(
         0,
@@ -1557,11 +1566,11 @@ CGImageRef IOSUsePlayCompositeWindowCaptures(
         ) ||
         !IOSUseCompositorApproximatelyEqual(
             deviceFrame.size.width,
-            IOSUsePlayDeviceLogicalWidth
+            IOSUseCompositorDeviceLogicalWidth
         ) ||
         !IOSUseCompositorApproximatelyEqual(
             deviceFrame.size.height,
-            IOSUsePlayDeviceLogicalHeight
+            IOSUseCompositorDeviceLogicalHeight
         )) {
         if (failure != NULL) {
             *failure = [NSString stringWithFormat:
@@ -1681,13 +1690,13 @@ CGImageRef IOSUsePlayCompositeWindowCaptures(
         }
         CGRect destinationNativeRect = CGRectMake(
             capture.deviceLogicalRect.origin.x *
-                IOSUsePlayDeviceScale,
+                IOSUseCompositorDeviceScale,
             capture.deviceLogicalRect.origin.y *
-                IOSUsePlayDeviceScale,
+                IOSUseCompositorDeviceScale,
             capture.deviceLogicalRect.size.width *
-                IOSUsePlayDeviceScale,
+                IOSUseCompositorDeviceScale,
             capture.deviceLogicalRect.size.height *
-                IOSUsePlayDeviceScale
+                IOSUseCompositorDeviceScale
         );
         [evidence addObject:@{
             @"windowNumber": number,
@@ -1760,8 +1769,7 @@ CGImageRef IOSUsePlayCompositeWindowCaptures(
         8,
         rowBytes,
         colorSpace,
-        kCGBitmapByteOrder32Little |
-            kCGImageAlphaPremultipliedFirst
+        IOSUseCompositorBitmapInfo
     );
     CGColorSpaceRelease(colorSpace);
     if (context == NULL) {
@@ -1779,16 +1787,16 @@ CGImageRef IOSUsePlayCompositeWindowCaptures(
          remaining -= 1) {
         IOSUsePlayWindowCapture capture = captures[remaining - 1];
         CGFloat relativeBottom =
-            IOSUsePlayDeviceLogicalHeight -
+            IOSUseCompositorDeviceLogicalHeight -
             CGRectGetMaxY(capture.deviceLogicalRect);
         CGRect destination = CGRectMake(
             capture.deviceLogicalRect.origin.x *
-                IOSUsePlayDeviceScale,
-            relativeBottom * IOSUsePlayDeviceScale,
+                IOSUseCompositorDeviceScale,
+            relativeBottom * IOSUseCompositorDeviceScale,
             capture.deviceLogicalRect.size.width *
-                IOSUsePlayDeviceScale,
+                IOSUseCompositorDeviceScale,
             capture.deviceLogicalRect.size.height *
-                IOSUsePlayDeviceScale
+                IOSUseCompositorDeviceScale
         );
         CGContextDrawImage(context, destination, capture.image);
     }

--- a/scripts/test_playcover_live_workflow_contract.sh
+++ b/scripts/test_playcover_live_workflow_contract.sh
@@ -88,6 +88,16 @@ validate_disposable_secret_bindings() {
 validate_workflow() {
   local file="$1"
 
+  require_exact_line \
+    "$file" \
+    '  mac-runtime-build:' \
+    "the hosted Mac Runtime compile job" ||
+    return 1
+  require_exact_line \
+    "$file" \
+    '        run: bash scripts/build_playcover_runtime.sh --output "$RUNNER_TEMP/IOSUsePlayRuntime.framework"' \
+    "the hosted Mac Runtime compile invocation" ||
+    return 1
   require_line_count \
     "$file" \
     '    runs-on: [self-hosted, macOS, arm64, playcover-live]' \


### PR DESCRIPTION
## Summary

- make fixed device geometry explicitly `CGFloat` where Xcode 26.6 diagnoses enum/float operations under `-Werror`
- make Core Graphics bitmap flags explicitly `CGBitmapInfo` without changing their bit pattern
- compile the Mac Runtime on hosted `macos-26` for every PR so release-only compiler failures are caught before tagging

## Validation

- Runtime build with `-Wenum-float-conversion -Wenum-enum-conversion` and `-Werror`
- `codesign --verify --strict` on the built Runtime framework
- 429 general Swift tests (3 skipped), 0 failures
- 313 Mac Swift tests (2 skipped), 0 failures
- deterministic Runtime/Frida/compositor/bridge/view-tree contracts
- all shell syntax and workflow contract tests

No live App or account-mutating gate was run locally.