### PR TITLE
fix(release): pin compatible Frida Python

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,7 @@ jobs:
         env:
           IOS_USE_RELEASE_VERSION: ${{ steps.resolve_tag.outputs.tag }}
           IOS_USE_PLAYCOVER_UPSTREAM_CACHE: ${{ runner.temp }}/ios-use-playcover-upstream-audit
+          PYTHON: /usr/bin/python3
         run: bash scripts/release_build.sh
 
       - name: Verify the exact release assets through an isolated install

--- a/scripts/build_playcover_frida_gum_catalyst.sh
+++ b/scripts/build_playcover_frida_gum_catalyst.sh
@@ -87,6 +87,10 @@ PYTHON="${PYTHON:-$(command -v python3)}"
 NINJA="${NINJA:-$(command -v ninja)}"
 [ -n "$PYTHON" ] || { echo "python3 is required" >&2; exit 69; }
 [ -n "$NINJA" ] || { echo "ninja is required" >&2; exit 69; }
+if ! "$PYTHON" -c 'import distutils.version' >/dev/null 2>&1; then
+  echo "the pinned Frida GLib code generator requires a Python interpreter with distutils; set PYTHON to a compatible interpreter" >&2
+  exit 69
+fi
 SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
 TARGET="arm64-apple-ios17.0-macabi"
 PKG_CONFIG_WRAPPER="$ROOT_DIR/scripts/frida_pkg_config.py"
@@ -145,12 +149,12 @@ chmod 755 "$NATIVE_PKG_CONFIG"
 
 "$PYTHON" - "$CONFIG_ROOT" "$SDK_PATH" "$TARGET" \
     "$TARGET_PKG_CONFIG" "$NATIVE_PKG_CONFIG" \
-    "$SOURCE_ROOT" "$GUM_BUILD" <<'PY'
+    "$SOURCE_ROOT" "$GUM_BUILD" "$PYTHON" <<'PY'
 import os
 import pathlib
 import sys
 
-root, sdk, target, target_pkg, native_pkg, source, gum_build = sys.argv[1:]
+root, sdk, target, target_pkg, native_pkg, source, gum_build, python = sys.argv[1:]
 root = pathlib.Path(root)
 source_argument = os.path.relpath(
     os.path.realpath(source),
@@ -168,6 +172,7 @@ ar = 'ar'
 ranlib = 'ranlib'
 strip = 'strip'
 pkg-config = '{target_pkg}'
+python = {python!r}
 
 [host_machine]
 system = 'darwin'
@@ -185,6 +190,7 @@ objcpp_args = {reproducible_args!r}
 '''
 native_file = f'''[binaries]
 pkg-config = '{native_pkg}'
+python = {python!r}
 
 [built-in options]
 c_args = {reproducible_args!r}
@@ -194,6 +200,7 @@ objcpp_args = {reproducible_args!r}
 '''
 cross_native = f'''[binaries]
 pkg-config = '{native_pkg}'
+python = {python!r}
 
 [built-in options]
 c_args = {reproducible_args!r}

--- a/scripts/test_playcover_live_workflow_contract.sh
+++ b/scripts/test_playcover_live_workflow_contract.sh
@@ -214,6 +214,11 @@ validate_release_workflow() {
     '        run: brew install xcodegen meson ninja' \
     "the clean hosted release build tools" ||
     return 1
+  require_exact_line \
+    "$file" \
+    '          PYTHON: /usr/bin/python3' \
+    "the compatible hosted Frida code-generation interpreter" ||
+    return 1
   if [[ "$(
     count_pattern \
       "$file" \


### PR DESCRIPTION
## Summary
- select the Xcode-provided Python for hosted release builds
- pass that interpreter through every Frida Meson machine file
- fail early when the pinned GLib code generator cannot import distutils
- pin the release workflow contract

## Root cause
Release run 31145532411 used Homebrew Python 3.14 through Meson; pinned GLib gdbus-codegen imports distutils, which Python 3.14 removed. Upload never ran and no release assets were published.

## Validation
- clean Frida Gum Catalyst build: 1031/1031, devkit generated
- original failing xdp-dbus and gdbus-daemon-generated steps passed with /usr/bin/python3
- all shell scripts pass bash -n
- packaging metadata positive/negative contract passes
- hosted workflow contract passes
- git diff --check passes