### PR TITLE
fix(release): link pinned Frida SQLite archive

### DIFF
--- a/scripts/build_playcover_frida_engine.sh
+++ b/scripts/build_playcover_frida_engine.sh
@@ -144,6 +144,11 @@ GUM_DEVKIT="$(cd "$GUM_DEVKIT" && pwd)"
 GUM_BUILD="${GUM_BUILD:-$(cd "$GUM_DEVKIT/../../.." && pwd)}"
 [ -f "$GUM_DEVKIT/frida-gumjs.h" ] || { echo "missing frida-gumjs.h" >&2; exit 65; }
 [ -f "$GUM_DEVKIT/libfrida-gumjs.a" ] || { echo "missing libfrida-gumjs.a" >&2; exit 65; }
+SQLITE_ARCHIVE="$GUM_BUILD/subprojects/sqlite/libsqlite3.a"
+[ -f "$SQLITE_ARCHIVE" ] || {
+  echo "missing pinned GumJS SQLite archive: $SQLITE_ARCHIVE" >&2
+  exit 65
+}
 
 if [ "$(basename "$OUTPUT")" != "IOSUseFridaEngine.framework" ]; then
   echo "output must end in IOSUseFridaEngine.framework" >&2
@@ -209,7 +214,7 @@ clang -target "$TARGET" -fobjc-arc -Wall -Wextra -Werror \
 clang -target "$TARGET" -fobjc-arc -Wall -Wextra -Werror \
   -isysroot "$SDK_PATH" -dynamiclib "$BUILD_TEMP/IOSUseFridaEngine.o" \
   -o "$BUILD_TEMP/IOSUseFridaEngine" \
-  -L"$GUM_DEVKIT" -lfrida-gumjs \
+  "$GUM_DEVKIT/libfrida-gumjs.a" "$SQLITE_ARCHIVE" \
   -framework Foundation -framework CoreFoundation -framework Security \
   -framework SystemConfiguration -lz -liconv -lresolv -lm \
   -install_name '@rpath/IOSUseFridaEngine.framework/IOSUseFridaEngine'


### PR DESCRIPTION
## Summary
- require the pinned SQLite archive produced by the same Frida Gum Catalyst build
- link it explicitly into IOSUseFridaEngine instead of relying on the upstream devkit pkg-config closure
- keep SQLite static and preserve the reviewed notice/corresponding-source contract

## Root cause
Frida GumJS enables its database bindings, but the pinned upstream `frida-gumjs-1.0.pc` omits SQLite from `Requires.private`. A clean release therefore generated the devkit successfully and then failed to link the Engine with unresolved `sqlite3_*` symbols.

## Validation
- clean Meson 1.11.2 Gum Catalyst build: 1031/1031 tasks
- wrapper Engine linked and ad-hoc signature verified
- Engine live harness passed
- static-closure notice audit passed; no dynamic SQLite dependency
- packaging metadata contract passed
- workflow contract passed
- all shell scripts pass `bash -n`
- `git diff --check` passed